### PR TITLE
test: 테스트를 커밋할 수 있게 하고 컴파일되지 않던 테스트를 살린다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,11 @@ replay_pid*
 docs/_book
 
 # TODO: where does this rule come from?
+# Vue 템플릿에서 따라온 규칙이다. 이름이 test인 디렉터리를 전부 무시해서
+# backend/src/test까지 같이 무시되고 있었다. 그래서 백엔드 테스트를 새로 써도
+# 커밋되지 않았고, 저장소에는 테스트가 사실상 없는 상태로 남아 있었다.
 test/
+!backend/src/test/
 
 ### Vuejs ###
 # Recommended template: Node.gitignore

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:testcontainers") // Testcontainers BOM 관리
+    testImplementation("org.testcontainers:mongodb")
+    testImplementation("org.testcontainers:mysql")
     // Redis 전용 Testcontainer는 없으므로 GenericContainer 사용
 
     implementation("software.amazon.awssdk:s3:2.28.23")

--- a/backend/src/test/java/com/joying/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/joying/TestcontainersConfiguration.java
@@ -1,0 +1,27 @@
+package com.joying;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * 테스트용 Redis 컨테이너.
+ *
+ * <p>{@link JoyingApplicationTests}가 참조하지만 저장소에 없어 테스트 소스가 컴파일되지
+ * 않던 클래스다. 컨테이너는 JVM당 한 번만 띄우고 테스트가 끝나면 Ryuk이 정리한다.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+	private static final GenericContainer<?> REDIS_CONTAINER =
+		new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+			.withExposedPorts(6379);
+
+	static {
+		REDIS_CONTAINER.start();
+	}
+
+	public static GenericContainer<?> getRedisContainer() {
+		return REDIS_CONTAINER;
+	}
+}


### PR DESCRIPTION
Closes #1

`.gitignore`에서 백엔드 테스트 소스를 추적하도록 뺐고, 저장소에 없어 컴파일을 막던 `TestcontainersConfiguration`을 만들었다.

이 PR이 먼저 머지돼야 다른 PR의 테스트가 커밋되고 컴파일된다.