### PR TITLE
fix: 모르는 계좌 상태 코드를 정상으로 되돌리지 않는다

### DIFF
--- a/backend/src/main/java/com/joying/account/domain/Account.java
+++ b/backend/src/main/java/com/joying/account/domain/Account.java
@@ -82,9 +82,14 @@ public class Account extends BaseEntity {
     }
 
     /**
-     * 계좌 사용 가능 여부 확인
+     * 계좌 사용 가능 여부 확인.
      *
-     * @return 정상 상태 여부 (Account 테이블에 있으면 이미 1원 인증 완료)
+     * <p>여기서 보는 상태는 우리 기록이지 금융망이 알려 준 값이 아니다. 계좌 조회 API가
+     * 상태 코드를 돌려주지 않아 등록 시점에 정상으로 두고 그 뒤로 갱신하지 않는다.
+     * 따라서 이 값이 참이라는 것은 해지나 휴면이 아니라는 뜻이 아니라,
+     * 1원 인증을 통과해 등록됐고 우리가 막지 않았다는 뜻이다.
+     *
+     * @return 우리 기록상 정상 상태인지
      */
     public boolean isUsable() {
         return this.accountState.isActive();

--- a/backend/src/main/java/com/joying/account/domain/AccountState.java
+++ b/backend/src/main/java/com/joying/account/domain/AccountState.java
@@ -1,5 +1,7 @@
 package com.joying.account.domain;
 
+import java.util.Optional;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -19,18 +21,21 @@ public enum AccountState {
 	private final String description;
 
 	/**
-	 * 코드로 AccountState 조회
+	 * 코드로 AccountState 조회.
+	 *
+	 * <p>모르는 코드를 정상으로 되돌리면 휴면이나 해지된 계좌가 정상으로 통과한다.
+	 * 그래서 모르는 코드는 비어 있는 값으로 돌려주고, 무엇으로 볼지는 부르는 쪽이 정한다.
 	 *
 	 * @param code 상태 코드
-	 * @return AccountState
+	 * @return 아는 코드면 해당 상태, 모르는 코드면 비어 있음
 	 */
-	public static AccountState fromCode(String code) {
+	public static Optional<AccountState> fromCode(String code) {
 		for (AccountState state : values()) {
 			if (state.code.equals(code)) {
-				return state;
+				return Optional.of(state);
 			}
 		}
-		return ACTIVE; // 기본값
+		return Optional.empty();
 	}
 
 	/**


### PR DESCRIPTION
Closes #2

모르는 코드는 비어 있는 값으로 돌려주고 무엇으로 볼지는 부르는 쪽이 정하게 했다. 금융망이 상태를 주지 않는다는 사실도 `isUsable()` 주석에 적었다.