### PR TITLE
fix: 채팅 메시지 인덱스가 실제로 쓰는 컬렉션에 붙게 한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,11 @@ replay_pid*
 docs/_book
 
 # TODO: where does this rule come from?
+# Vue 템플릿에서 따라온 규칙이다. 이름이 test인 디렉터리를 전부 무시해서
+# backend/src/test까지 같이 무시되고 있었다. 그래서 백엔드 테스트를 새로 써도
+# 커밋되지 않았고, 저장소에는 테스트가 사실상 없는 상태로 남아 있었다.
 test/
+!backend/src/test/
 
 ### Vuejs ###
 # Recommended template: Node.gitignore

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:testcontainers") // Testcontainers BOM 관리
+    testImplementation("org.testcontainers:mongodb")
+    testImplementation("org.testcontainers:mysql")
     // Redis 전용 Testcontainer는 없으므로 GenericContainer 사용
 
     implementation("software.amazon.awssdk:s3:2.28.23")

--- a/backend/src/main/kotlin/com/joying/chat/config/MongoConfig.kt
+++ b/backend/src/main/kotlin/com/joying/chat/config/MongoConfig.kt
@@ -1,5 +1,6 @@
 package com.joying.chat.config
 
+import com.joying.chat.document.ChatMessage
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -51,33 +52,22 @@ class MongoConfig {
     /**
      * MongoDB 인덱스 초기화
      *
-     * 애플리케이션 시작 시 필요한 인덱스를 자동으로 생성
-     * 기존 인덱스가 있으면 삭제 후 재생성
+     * 애플리케이션 시작 시 필요한 인덱스를 만든다.
+     *
+     * ensureIndex는 없을 때만 만들므로 여러 번 불러도 안전하다. 예전에는 기동할 때마다
+     * _id를 뺀 인덱스를 전부 지우고 다시 만들었는데, 그러면 배포할 때마다 인덱스가
+     * 사라졌다가 다시 쌓이는 동안 조회가 전부 컬렉션 스캔으로 돈다.
      */
     private fun initIndexes(mongoTemplate: MongoTemplate) {
         try {
-            val indexOps = mongoTemplate.indexOps("chatMessages")
-
-            // 기존 인덱스 목록 조회
-            val existingIndexes = indexOps.indexInfo
-
-            // 모든 인덱스 삭제 (_id 인덱스 제외)
-            existingIndexes.forEach { indexInfo ->
-                val indexName = indexInfo.name
-                if (indexName != "_id_") {
-                    try {
-                        indexOps.dropIndex(indexName)
-                        logger.debug("기존 인덱스 삭제: {}", indexName)
-                    } catch (e: Exception) {
-                        logger.warn("인덱스 삭제 실패 (무시): {} - {}", indexName, e.message)
-                    }
-                }
-            }
+            // 컬렉션 이름을 문자열로 적으면 @Document의 이름과 어긋나도 아무 신호가 없다.
+            // 실제로 "chatMessages"로 적혀 있어 아래 인덱스가 전부 없는 컬렉션에 만들어지고 있었다.
+            // 엔티티에서 이름을 받아 두 곳이 갈라질 수 없게 한다.
+            val indexOps = mongoTemplate.indexOps(ChatMessage::class.java)
 
             // 1. 안읽은 메시지 카운트 쿼리 최적화 (P0 - Critical)
             // countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot
             // 복합 인덱스: chatRoomId + isDeleted + createdAt + senderId
-            // 예상 성능 개선: 500ms → 5ms (100배 향상)
             indexOps.ensureIndex(
                 Index()
                     .on("chatRoomId", Sort.Direction.ASC)
@@ -108,7 +98,7 @@ class MongoConfig {
                     .named("idx_missed_messages_asc")
             )
 
-            logger.info("MongoDB 인덱스 초기화 완료 (chatMessages)")
+            logger.info("MongoDB 인덱스 초기화 완료: {}", mongoTemplate.getCollectionName(ChatMessage::class.java))
         } catch (e: Exception) {
             logger.error("MongoDB 인덱스 초기화 실패: ${e.message}", e)
         }

--- a/backend/src/test/java/com/joying/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/joying/TestcontainersConfiguration.java
@@ -1,0 +1,27 @@
+package com.joying;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * 테스트용 Redis 컨테이너.
+ *
+ * <p>{@link JoyingApplicationTests}가 참조하지만 저장소에 없어 테스트 소스가 컴파일되지
+ * 않던 클래스다. 컨테이너는 JVM당 한 번만 띄우고 테스트가 끝나면 Ryuk이 정리한다.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+	private static final GenericContainer<?> REDIS_CONTAINER =
+		new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+			.withExposedPorts(6379);
+
+	static {
+		REDIS_CONTAINER.start();
+	}
+
+	public static GenericContainer<?> getRedisContainer() {
+		return REDIS_CONTAINER;
+	}
+}

--- a/backend/src/test/java/com/joying/chat/ChatMessageIndexTest.java
+++ b/backend/src/test/java/com/joying/chat/ChatMessageIndexTest.java
@@ -1,0 +1,79 @@
+package com.joying.chat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.index.Index;
+import org.testcontainers.containers.MongoDBContainer;
+
+import com.joying.chat.document.ChatMessage;
+
+/**
+ * 채팅 메시지 인덱스가 실제 컬렉션에 붙는지 확인한다.
+ *
+ * <p>인덱스를 만드는 코드는 컬렉션 이름을 문자열 {@code "chatMessages"}로 적고 있었고,
+ * 엔티티는 {@code chat_messages}에 저장하고 있었다. 두 이름이 어긋나면 인덱스는
+ * 아무 오류 없이 존재하지 않는 컬렉션에 만들어진다. 그 사실을 이 테스트로 고정한다.
+ */
+class ChatMessageIndexTest {
+
+	private static MongoDBContainer mongo;
+	private static MongoTemplate mongoTemplate;
+
+	@BeforeAll
+	static void startMongo() {
+		mongo = new MongoDBContainer("mongo:7.0");
+		mongo.start();
+		mongoTemplate = new MongoTemplate(
+			new SimpleMongoClientDatabaseFactory(mongo.getConnectionString() + "/joying_test"));
+	}
+
+	@AfterAll
+	static void stopMongo() {
+		if (mongo != null) {
+			mongo.stop();
+		}
+	}
+
+	@Test
+	@DisplayName("엔티티에서 컬렉션 이름을 받으면 @Document가 가리키는 chat_messages에 인덱스가 붙는다")
+	void indexLandsOnTheCollectionEntityWritesTo() {
+		mongoTemplate.indexOps(ChatMessage.class).ensureIndex(
+			new Index()
+				.on("chatRoomId", Sort.Direction.ASC)
+				.on("isDeleted", Sort.Direction.ASC)
+				.on("createdAt", Sort.Direction.ASC)
+				.named("idx_unread_count"));
+
+		assertThat(mongoTemplate.getCollectionName(ChatMessage.class)).isEqualTo("chat_messages");
+		assertThat(indexNamesOf("chat_messages")).contains("idx_unread_count");
+	}
+
+	@Test
+	@DisplayName("컬렉션 이름을 문자열로 적으면 오류 없이 다른 컬렉션에 인덱스가 만들어진다")
+	void wrongNameSilentlyCreatesAnotherCollection() {
+		mongoTemplate.indexOps("chatMessages").ensureIndex(
+			new Index().on("chatRoomId", Sort.Direction.ASC).named("idx_typo"));
+
+		// 예외가 나지 않는다. 그래서 이 오타는 기동 로그만 봐서는 드러나지 않았다.
+		assertThat(indexNamesOf("chatMessages")).contains("idx_typo");
+		assertThat(indexNamesOf("chat_messages")).doesNotContain("idx_typo");
+	}
+
+	private List<String> indexNamesOf(String collection) {
+		return mongoTemplate.getCollection(collection)
+			.listIndexes()
+			.map(Document.class::cast)
+			.map(d -> d.getString("name"))
+			.into(new java.util.ArrayList<>());
+	}
+}


### PR DESCRIPTION
Closes #3
Base: #9 (chore/test-infra)

컬렉션 이름을 엔티티에서 받아 두 곳이 갈라질 수 없게 했다. 기동마다 인덱스를 지우고 다시 만들던 것도 뺐다.

테스트로 오타를 재현해 뒀다. 문자열로 적으면 예외 없이 다른 컬렉션에 만들어진다는 것이 이 버그가 기동 로그로 드러나지 않은 이유다.