### PR TITLE
feat: 미확정으로 남은 입금을 금융망에 다시 물어 확정한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,7 +137,11 @@ replay_pid*
 docs/_book
 
 # TODO: where does this rule come from?
+# Vue 템플릿에서 따라온 규칙이다. 이름이 test인 디렉터리를 전부 무시해서
+# backend/src/test까지 같이 무시되고 있었다. 그래서 백엔드 테스트를 새로 써도
+# 커밋되지 않았고, 저장소에는 테스트가 사실상 없는 상태로 남아 있었다.
 test/
+!backend/src/test/
 
 ### Vuejs ###
 # Recommended template: Node.gitignore

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:testcontainers") // Testcontainers BOM 관리
+    testImplementation("org.testcontainers:mongodb")
+    testImplementation("org.testcontainers:mysql")
     // Redis 전용 Testcontainer는 없으므로 GenericContainer 사용
 
     implementation("software.amazon.awssdk:s3:2.28.23")

--- a/backend/src/main/java/com/joying/common/config/ssafy/FinanceApiClientConfig.java
+++ b/backend/src/main/java/com/joying/common/config/ssafy/FinanceApiClientConfig.java
@@ -1,0 +1,33 @@
+package com.joying.common.config.ssafy;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * SSAFY 금융망 API 호출용 RestTemplate 설정.
+ *
+ * <p>금융망 호출은 실제로 계좌 사이에 돈을 옮긴다. 응답을 기다리는 시간에 제한이 없으면
+ * 상대가 멈췄을 때 우리 스레드가 같이 멈추고, 그 사이 들어온 요청까지 밀린다.
+ *
+ * <p>값은 {@code ssafy.finance.connect-timeout}, {@code ssafy.finance.read-timeout}으로
+ * 바꿀 수 있다. 상대 서버의 응답 분포는 환경마다 다르고, 값을 조정하려고 배포를 다시 하지
+ * 않기 위해 상수로 박지 않았다.
+ */
+@Configuration
+@RequiredArgsConstructor
+public class FinanceApiClientConfig {
+
+	private final FinanceApiProperties financeApiProperties;
+
+	@Bean
+	public RestTemplate financeApiRestTemplate(RestTemplateBuilder builder) {
+		return builder
+			.connectTimeout(financeApiProperties.getConnectTimeout())
+			.readTimeout(financeApiProperties.getReadTimeout())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/joying/common/config/ssafy/FinanceApiProperties.java
+++ b/backend/src/main/java/com/joying/common/config/ssafy/FinanceApiProperties.java
@@ -2,6 +2,8 @@ package com.joying.common.config.ssafy;
 
 import lombok.Getter;
 import lombok.Setter;
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,6 +35,19 @@ public class FinanceApiProperties {
 	 * 핀테크 앱 번호 (고정값: 001)
 	 */
 	private String fintechAppNo = "001";
+
+	/**
+	 * 연결을 맺는 데까지 기다리는 시간.
+	 * 상대 서버가 살아 있는지를 가리는 값이라 짧게 잡아도 오탐이 적다.
+	 */
+	private Duration connectTimeout = Duration.ofSeconds(2);
+
+	/**
+	 * 연결된 뒤 응답 본문을 기다리는 시간.
+	 * 이 시간이 지나면 송금이 성공했는지 알 수 없는 상태로 남으므로,
+	 * 이 값을 줄이려면 미확정을 확정해 주는 복구 경로가 먼저 있어야 한다.
+	 */
+	private Duration readTimeout = Duration.ofSeconds(5);
 
 	/**
 	 * Joying 중개 계좌 정보 (에스크로)

--- a/backend/src/main/java/com/joying/escrow/domain/Escrow.java
+++ b/backend/src/main/java/com/joying/escrow/domain/Escrow.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Timestamp;
 
@@ -17,7 +18,6 @@ import java.sql.Timestamp;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "holdId", callSuper = false)
 public class Escrow {
-    public static Status Status;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hold_id")
@@ -50,6 +50,23 @@ public class Escrow {
     @Column(name="status")
     private Status status;
 
+    @Comment("생성 시각. 미확정 입금을 재조회할 때 조회 창을 이 시각으로 좁힌다")
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Timestamp createdAt;
+
+    @Comment("에스크로 입금 거래고유번호. 미확정 건을 재조회할 때 열쇠가 된다")
+    @Column(name = "deposit_tx_no")
+    private String depositTxNo;
+
+    @Comment("대여료 지급 거래고유번호. 있으면 이미 나간 것이므로 다시 보내지 않는다")
+    @Column(name = "rental_fee_tx_no")
+    private String rentalFeeTxNo;
+
+    @Comment("보증금 반환 거래고유번호. 있으면 이미 나간 것이므로 다시 보내지 않는다")
+    @Column(name = "deposit_return_tx_no")
+    private String depositReturnTxNo;
+
     @Comment("대여료지급 일시")
     @Column(name = "rental_fee_released_at")
     private Timestamp rentalFeeReleasedAt;
@@ -59,7 +76,7 @@ public class Escrow {
     private Timestamp depositReturnedAt;
 
     /**
-     * Escrow 생성 (결제 완료 후)
+     * Escrow 생성 (토스 결제 승인 직후, 금융망 입금 전)
      *
      * @param rentalHistory 거래 내역
      * @param payment       결제 정보
@@ -67,7 +84,7 @@ public class Escrow {
      * @param depositAmount 보증금
      * @return Escrow 엔티티
      */
-    public static Escrow createHeld(RentalHistory rentalHistory,
+    public static Escrow createPending(RentalHistory rentalHistory,
                                      Payment payment,
                                      Integer rentalFee,
                                      Integer depositAmount) {
@@ -77,8 +94,26 @@ public class Escrow {
         escrow.rentalFee = rentalFee;
         escrow.depositAmount = depositAmount;
         escrow.totalAmount = rentalFee + depositAmount;
-        escrow.status = Status.HELD;  // 홀드 완료(예치중)
+        escrow.status = Status.PENDING;  // 금융망 입금이 확정되기 전
         return escrow;
+    }
+
+    /**
+     * 금융망 입금이 성공으로 확정됐다. 거래고유번호를 남기고 예치중으로 옮긴다.
+     */
+    public void markHeld(String depositTxNo) {
+        if (this.status != Status.PENDING) {
+            throw new IllegalStateException("PENDING 상태에서만 예치로 옮길 수 있습니다.");
+        }
+        this.depositTxNo = depositTxNo;
+        this.status = Status.HELD;
+    }
+
+    /**
+     * 입금 결과가 미확정인지. PENDING으로 남아 있으면 금융망에 다시 물어 확정해야 한다.
+     */
+    public boolean isDepositUnconfirmed() {
+        return this.status == Status.PENDING;
     }
 
     /**
@@ -106,6 +141,39 @@ public class Escrow {
      */
     public void releaseRentalFee(Timestamp releasedAt) {
         this.rentalFeeReleasedAt = releasedAt;
+    }
+
+    /**
+     * 대여료 지급이 성공으로 확정됐다. 거래고유번호를 남긴다.
+     *
+     * <p>이 번호가 남아 있으면 이미 나간 돈이다. 정산을 다시 돌려도 이 단계는 건너뛴다.
+     * 순차로 나가는 송금 중 뒤엣것이 실패했을 때 앞엣것을 다시 보내지 않기 위한 표식이다.
+     */
+    public void markRentalFeeSent(String transactionUniqueNo, Timestamp releasedAt) {
+        this.rentalFeeTxNo = transactionUniqueNo;
+        this.rentalFeeReleasedAt = releasedAt;
+    }
+
+    /**
+     * 보증금 반환이 성공으로 확정됐다. 거래고유번호를 남긴다.
+     */
+    public void markDepositReturned(String transactionUniqueNo, Timestamp returnedAt) {
+        this.depositReturnTxNo = transactionUniqueNo;
+        this.depositReturnedAt = returnedAt;
+    }
+
+    /**
+     * 대여료가 이미 나갔는지. 참이면 다시 보내면 안 된다.
+     */
+    public boolean isRentalFeeSent() {
+        return this.rentalFeeTxNo != null;
+    }
+
+    /**
+     * 보증금이 이미 반환됐는지. 참이면 다시 보내면 안 된다.
+     */
+    public boolean isDepositReturned() {
+        return this.depositReturnTxNo != null;
     }
 
     /**

--- a/backend/src/main/java/com/joying/escrow/service/EscrowDepositRecoveryService.java
+++ b/backend/src/main/java/com/joying/escrow/service/EscrowDepositRecoveryService.java
@@ -1,0 +1,142 @@
+package com.joying.escrow.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joying.common.config.ssafy.FinanceApiProperties;
+import com.joying.escrow.domain.Escrow;
+import com.joying.escrow.domain.Status;
+import com.joying.escrow.repository.EscrowRepository;
+import com.joying.ssafy.dto.InquireTransactionHistoryResponse;
+import com.joying.ssafy.service.FinanceApiService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 에스크로 입금이 미확정으로 남은 건을 금융망에 다시 물어 확정한다.
+ *
+ * <p>입금 호출이 타임아웃 나면 돈이 들어갔는지 알 수 없다. 그 자리에서 실패로 확정하면
+ * 실제로 들어간 돈을 장부에서 지우게 되므로 되돌리지 않고 {@code PENDING}으로 남긴다.
+ * 남긴 건을 닫는 것이 이 작업이다.
+ *
+ * <p>미확정 건은 거래고유번호를 받지 못했으므로 단건 조회로는 확인할 수 없다. 대신
+ * 입금할 때 거래 요약에 주문번호를 심어 두었고, 계좌의 기간별 거래 목록에서 그 주문번호로
+ * 찾는다. 같은 주문번호로 두 번 입금되는 일이 없으므로 이 요약이 사실상의 열쇠가 된다.
+ *
+ * <p>찾지 못했다고 해서 실패로 확정하지 않는다. 조회가 실패했을 수도 있고 금융망 반영이
+ * 늦을 수도 있다. 확정할 근거가 없으면 그대로 두고 다음 주기에 다시 묻는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EscrowDepositRecoveryService {
+
+	private static final DateTimeFormatter YYYYMMDD = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+	/**
+	 * 이 시간이 지나도록 확정되지 않은 건은 사람이 봐야 한다.
+	 */
+	private static final Duration NEEDS_ATTENTION_AFTER = Duration.ofMinutes(10);
+
+	private final EscrowRepository escrowRepository;
+	private final FinanceApiService financeApiService;
+	private final FinanceApiProperties financeApiProperties;
+
+	@Scheduled(fixedDelayString = "${joying.escrow.deposit-recovery.interval-ms:60000}")
+	@Transactional
+	public void confirmUnconfirmedDeposits() {
+		List<Escrow> unconfirmed = escrowRepository.findByStatus(Status.PENDING);
+		if (unconfirmed.isEmpty()) {
+			return;
+		}
+
+		log.info("[에스크로 입금 재조회] 대상 {}건", unconfirmed.size());
+
+		String escrowAccountNo = financeApiProperties.getEscrow().getAccountNo();
+		String escrowUserKey = financeApiProperties.getEscrow().getUserKey();
+
+		// 조회 창을 가장 오래된 미확정 건의 생성 시각까지로 넓힌다. 창이 좁으면 실제로 들어온
+		// 입금을 못 찾고, 못 찾은 것을 근거로 무언가 판단하면 그 판단이 틀린다.
+		String startDate = earliestCreatedDate(unconfirmed).format(YYYYMMDD);
+		String endDate = LocalDate.now().format(YYYYMMDD);
+
+		List<InquireTransactionHistoryResponse.TransactionRec> transactions;
+		try {
+			transactions = financeApiService.inquireTransactionHistoryList(
+				escrowAccountNo, startDate, endDate, escrowUserKey);
+		} catch (Exception e) {
+			// 조회가 실패한 것을 "거래가 없었다"로 읽으면 안 된다. 아무것도 확정하지 않고 물러난다.
+			log.error("[에스크로 입금 재조회] 거래내역 조회 실패. 이번 주기에는 확정하지 않는다", e);
+			return;
+		}
+
+		int confirmed = 0;
+		int needsAttention = 0;
+		for (Escrow escrow : unconfirmed) {
+			String orderId = orderIdOf(escrow);
+			if (orderId == null) {
+				log.warn("[에스크로 입금 재조회] 주문번호가 없어 찾을 수 없다: escrowId={}", escrow.getHoldId());
+				continue;
+			}
+
+			InquireTransactionHistoryResponse.TransactionRec matched = transactions.stream()
+				.filter(tx -> tx.getTransactionSummary() != null
+					&& tx.getTransactionSummary().contains(orderId))
+				.findFirst()
+				.orElse(null);
+
+			if (matched != null) {
+				escrow.markHeld(matched.getTransactionUniqueNo());
+				confirmed++;
+				log.info("[에스크로 입금 확정] escrowId={}, orderId={}, txNo={}",
+					escrow.getHoldId(), orderId, matched.getTransactionUniqueNo());
+				continue;
+			}
+
+			// 조회 창이 이 건의 생성 시각을 덮고 있는데도 거래가 없다면 입금이 실제로 나가지
+			// 않은 것이다. 그래도 여기서 자동으로 다시 보내지는 않는다. 없다는 것을 근거로
+			// 돈을 옮기는 판단은, 조회가 정말 전부를 보여 준다는 것을 확인한 뒤에 켠다.
+			if (isOlderThan(escrow, NEEDS_ATTENTION_AFTER)) {
+				needsAttention++;
+				log.error("[에스크로 입금 미확정 장기화 - 사람이 확인해야 함] escrowId={}, orderId={}, 생성={}",
+					escrow.getHoldId(), orderId, escrow.getCreatedAt());
+			} else {
+				log.info("[에스크로 입금 재조회] 아직 확인되지 않음: escrowId={}, orderId={}",
+					escrow.getHoldId(), orderId);
+			}
+		}
+
+		log.info("[에스크로 입금 재조회] 확정 {}건, 미확정 {}건 (그중 장기 {}건)",
+			confirmed, unconfirmed.size() - confirmed, needsAttention);
+	}
+
+	/**
+	 * 가장 오래된 미확정 건의 생성 날짜. 생성 시각을 모르는 건이 있으면 전날까지 넓힌다.
+	 */
+	private LocalDate earliestCreatedDate(List<Escrow> escrows) {
+		LocalDate fallback = LocalDate.now().minusDays(1);
+		return escrows.stream()
+			.map(Escrow::getCreatedAt)
+			.map(ts -> ts == null ? null : ts.toLocalDateTime().toLocalDate())
+			.map(d -> d == null ? fallback : d)
+			.min(LocalDate::compareTo)
+			.orElse(fallback);
+	}
+
+	private boolean isOlderThan(Escrow escrow, Duration duration) {
+		return escrow.getCreatedAt() != null
+			&& escrow.getCreatedAt().toInstant().isBefore(Instant.now().minus(duration));
+	}
+
+	private String orderIdOf(Escrow escrow) {
+		return escrow.getPayment() == null ? null : escrow.getPayment().getOrderId();
+	}
+}

--- a/backend/src/main/java/com/joying/escrow/service/EscrowService.java
+++ b/backend/src/main/java/com/joying/escrow/service/EscrowService.java
@@ -1,8 +1,11 @@
 package com.joying.escrow.service;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import com.joying.account.domain.Account;
 import com.joying.common.config.ssafy.FinanceApiProperties;
 import com.joying.escrow.domain.Escrow;
+import com.joying.ssafy.dto.TransferOutcome;
 import com.joying.escrow.dto.request.EscrowCreateRequest;
 import com.joying.escrow.dto.response.EscrowResponse;
 import com.joying.escrow.repository.EscrowRepository;
@@ -57,7 +60,8 @@ public class EscrowService {
         }
 
         // 4. Escrow 생성
-        Escrow escrow = Escrow.createHeld(
+        // 이 경로도 금융망 입금을 하지 않으므로 예치 완료를 주장하지 않는다.
+        Escrow escrow = Escrow.createPending(
                 rental,
                 payment,
                 rental.getFee(),
@@ -144,40 +148,60 @@ public class EscrowService {
         String escrowUserKey = financeApiProperties.getEscrow().getUserKey();
 
         // 4. SSAFY 금융망으로 대여료 지급 (Joying 중개 계좌 → 대여자)
-        try {
-            String rentalFeeTxNo = financeApiService.transferMoney(
+        //
+        // 송금 두 건이 순차로 나간다. 예전에는 뒤엣것이 실패하면 예외를 던져 트랜잭션을
+        // 되돌렸는데, 롤백은 DB만 되돌리고 이미 나간 돈은 되돌리지 못한다. 그 상태로
+        // 정산을 다시 돌리면 앞엣것이 한 번 더 나갔다.
+        //
+        // 그래서 확정된 송금은 거래고유번호를 남겨 두고, 다시 돌 때 그 단계를 건너뛴다.
+        // 확정한 뒤에는 예외를 던지지 않는다. 던지면 방금 남긴 기록까지 같이 사라진다.
+        if (!escrow.isRentalFeeSent()) {
+            TransferOutcome outcome = financeApiService.transferMoney(
                     escrowAccountNo,
                     lenderAccount.getAccountNo(),
                     escrow.getRentalFee().longValue(),
                     "Joying 대여료 지급",
                     escrowUserKey
             );
-            log.info("[대여료 지급 완료] rentalHisId={}, txNo={}, amount={}, to={}",
-                    rental.getRentalHisId(), rentalFeeTxNo, escrow.getRentalFee(), lenderAccount.getAccountNo());
-        } catch (Exception e) {
-            log.error("[대여료 지급 실패] rentalHisId={}, lenderMemberId={}",
-                    rental.getRentalHisId(), lender.getMemberId(), e);
-            throw new IllegalStateException("대여료 지급 중 오류가 발생했습니다", e);
+
+            if (outcome instanceof TransferOutcome.Succeeded succeeded) {
+                escrow.markRentalFeeSent(succeeded.transactionUniqueNo(),
+                        Timestamp.from(Instant.now()));
+                log.info("[대여료 지급 완료] rentalHisId={}, txNo={}, amount={}, to={}",
+                        rental.getRentalHisId(), succeeded.transactionUniqueNo(),
+                        escrow.getRentalFee(), lenderAccount.getAccountNo());
+            } else {
+                log.error("[대여료 지급 미완료 - 정산 중단] holdId={}, rentalHisId={}, outcome={}",
+                        holdId, rental.getRentalHisId(), outcome);
+                return convertToResponse(escrow);
+            }
         }
 
         // 5. SSAFY 금융망으로 보증금 반환 (Joying 중개 계좌 → 차용자)
-        try {
-            String depositTxNo = financeApiService.transferMoney(
+        if (!escrow.isDepositReturned()) {
+            TransferOutcome outcome = financeApiService.transferMoney(
                     escrowAccountNo,
                     renterAccount.getAccountNo(),
                     escrow.getDepositAmount().longValue(),
                     "Joying 보증금 반환",
                     escrowUserKey
             );
-            log.info("[보증금 반환 완료] rentalHisId={}, txNo={}, amount={}, to={}",
-                    rental.getRentalHisId(), depositTxNo, escrow.getDepositAmount(), renterAccount.getAccountNo());
-        } catch (Exception e) {
-            log.error("[보증금 반환 실패] rentalHisId={}, renterMemberId={}",
-                    rental.getRentalHisId(), renter.getMemberId(), e);
-            throw new IllegalStateException("보증금 반환 중 오류가 발생했습니다", e);
+
+            if (outcome instanceof TransferOutcome.Succeeded succeeded) {
+                escrow.markDepositReturned(succeeded.transactionUniqueNo(),
+                        Timestamp.from(Instant.now()));
+                log.info("[보증금 반환 완료] rentalHisId={}, txNo={}, amount={}, to={}",
+                        rental.getRentalHisId(), succeeded.transactionUniqueNo(),
+                        escrow.getDepositAmount(), renterAccount.getAccountNo());
+            } else {
+                // 대여료는 이미 나갔고 그 기록이 남아 있다. 다시 돌리면 여기서부터 이어간다.
+                log.error("[보증금 반환 미완료 - 정산 중단] holdId={}, rentalHisId={}, outcome={}",
+                        holdId, rental.getRentalHisId(), outcome);
+                return convertToResponse(escrow);
+            }
         }
 
-        // 6. Escrow 상태 변경 (HELD → SETTLED)
+        // 6. 두 송금이 모두 확정됐을 때만 정산을 닫는다
         escrow.settle();
 
         // 7. RentalHistory 상태 업데이트 (RETURNED → DEPOSIT_RETURNED)

--- a/backend/src/main/java/com/joying/outbox/service/OutboxEventProcessor.java
+++ b/backend/src/main/java/com/joying/outbox/service/OutboxEventProcessor.java
@@ -137,7 +137,11 @@ public class OutboxEventProcessor {
         Integer rentalFee = rentalHistory.getFee();
         Integer depositAmount = rentalHistory.getDeposit().intValue();
 
-        Escrow escrow = Escrow.createHeld(rentalHistory, payment, rentalFee, depositAmount);
+        // 이 경로는 금융망 입금을 하지 않는다. 예전에는 여기서 바로 HELD로 만들었는데,
+        // 결제 쪽 동기 경로와 경합해 이쪽이 먼저 이기면 결제 쪽 입금 블록이 통째로
+        // 건너뛰어지면서 기록만 예치 완료가 되고 계좌에는 돈이 들어가지 않았다.
+        // 입금이 확정되기 전에는 PENDING으로 두고, 재조회 작업이 확정하게 한다.
+        Escrow escrow = Escrow.createPending(rentalHistory, payment, rentalFee, depositAmount);
         escrowRepository.save(escrow);
 
         log.info("[Outbox] Escrow 생성 완료: escrowId={}, paymentId={}", escrow.getHoldId(), paymentId);

--- a/backend/src/main/java/com/joying/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/joying/payment/service/PaymentService.java
@@ -23,6 +23,7 @@ import com.joying.product.repository.ProductRepository;
 import com.joying.rental.domain.RentalHistory;
 import com.joying.rental.repository.RentalHistoryRepository;
 import com.joying.escrow.domain.Escrow;
+import com.joying.ssafy.dto.TransferOutcome;
 import com.joying.escrow.repository.EscrowRepository;
 import com.joying.ssafy.service.FinanceApiService;
 import lombok.RequiredArgsConstructor;
@@ -385,45 +386,52 @@ public class PaymentService {
                 Integer depositAmount = rentalHistory.getDeposit().intValue();  // 보증금
                 Integer totalRentalFee = payment.getTotalAmount() - depositAmount;  // 전체 대여료 (결제금액 - 보증금)
 
-                Escrow escrow = Escrow.createHeld(rentalHistory, payment, totalRentalFee, depositAmount);
+                // 금융망 입금이 확정되기 전이므로 PENDING으로 만들어 먼저 저장한다.
+                // 이 행이 있어야 입금 결과가 미확정으로 남았을 때 나중에 찾아서 확정할 수 있다.
+                Escrow escrow = Escrow.createPending(rentalHistory, payment, totalRentalFee, depositAmount);
                 escrowRepository.save(escrow);
                 log.info("Escrow 생성 완료: escrowId={}, paymentId={}, rentalFee={}, deposit={}",
                         escrow.getHoldId(), payment.getPaymentId(), totalRentalFee, depositAmount);
 
                 // 토스 결제 완료 후 Joying 에스크로 계좌로 입금 (SSAFY 금융망)
                 // 실제 돈은 토스에 있고, SSAFY 금융망에는 논리적으로만 입금
-                try {
-                    String escrowAccountNo = financeApiProperties.getEscrow().getAccountNo();
-                    String escrowUserKey = financeApiProperties.getEscrow().getUserKey();
-                    // 실제 결제 금액 = (일일요금 × 일수) + 보증금 (payment.getTotalAmount()에 저장됨)
-                    long totalAmount = payment.getTotalAmount().longValue();
+                String escrowAccountNo = financeApiProperties.getEscrow().getAccountNo();
+                String escrowUserKey = financeApiProperties.getEscrow().getUserKey();
+                // 실제 결제 금액 = (일일요금 × 일수) + 보증금 (payment.getTotalAmount()에 저장됨)
+                long totalAmount = payment.getTotalAmount().longValue();
 
-                    // 에스크로 계좌에 입금 (출금 없이 입금만 수행)
-                    String txNo = financeApiService.depositMoney(
-                            escrowAccountNo,
-                            totalAmount,
-                            "Toss 결제 에스크로 입금 (orderId: " + payment.getOrderId() + ")",
-                            escrowUserKey
-                    );
+                TransferOutcome outcome = financeApiService.depositMoney(
+                        escrowAccountNo,
+                        totalAmount,
+                        "Toss 결제 에스크로 입금 (orderId: " + payment.getOrderId() + ")",
+                        escrowUserKey
+                );
 
+                if (outcome instanceof TransferOutcome.Succeeded succeeded) {
+                    escrow.markHeld(succeeded.transactionUniqueNo());
                     log.info("[에스크로 계좌 입금 완료] rentalHisId={}, txNo={}, amount={}, to={}",
-                            rentalHistory.getRentalHisId(), txNo, totalAmount, escrowAccountNo);
-                } catch (Exception e) {
-                    log.error("[에스크로 입금 실패] orderId={}, paymentKey={}",
-                             payment.getOrderId(), payment.getPaymentKey(), e);
+                            rentalHistory.getRentalHisId(), succeeded.transactionUniqueNo(),
+                            totalAmount, escrowAccountNo);
 
-                    // Toss 결제는 이미 승인되었으므로, 보상 트랜잭션으로 취소 시도
-                    try {
-                        log.info("[에스크로 입금 실패 - Toss 결제 자동 취소 시도] orderId={}", payment.getOrderId());
-                        tossClient.cancel(tossResponse.getPaymentKey(), "에스크로 계좌 입금 실패");
-                        log.info("[Toss 결제 취소 완료] orderId={}", payment.getOrderId());
-                    } catch (Exception cancelEx) {
-                        log.error("[Toss 결제 취소 실패 - 수동 처리 필요] orderId={}, paymentKey={}",
-                                 payment.getOrderId(), payment.getPaymentKey(), cancelEx);
-                    }
+                } else if (outcome instanceof TransferOutcome.Rejected rejected) {
+                    // 금융망이 요청을 받고 거절했다. 돈은 옮겨지지 않은 것이 확정이므로,
+                    // 이미 승인된 토스 결제를 되돌리는 것이 맞다.
+                    log.error("[에스크로 입금 거절] orderId={}, code={}, message={}",
+                            payment.getOrderId(), rejected.responseCode(), rejected.responseMessage());
+                    cancelTossPaymentForFailedDeposit(payment, tossResponse.getPaymentKey(),
+                            "에스크로 계좌 입금 거절");
+                    throw new IllegalStateException("에스크로 계좌 입금이 거절되었습니다: "
+                            + rejected.responseCode());
 
-                    // 트랜잭션 롤백을 위해 예외 재발생
-                    throw new IllegalStateException("에스크로 계좌 입금에 실패했습니다", e);
+                } else {
+                    // 입금이 됐는지 알 수 없다. 여기서 토스 결제를 취소하면
+                    // 실제로 입금이 성공했을 때 고객 돈만 돌아가고 에스크로 계좌에는 돈이 남는다.
+                    // 되돌리지 않고 PENDING으로 남겨 두었다가 거래내역 재조회로 확정한다.
+                    // 예외를 던지지 않는 이유는, 롤백하면 방금 남긴 PENDING 행까지 같이 사라져
+                    // 나중에 이 건을 찾을 방법이 없어지기 때문이다.
+                    TransferOutcome.Unconfirmed unconfirmed = (TransferOutcome.Unconfirmed) outcome;
+                    log.warn("[에스크로 입금 미확정 - 재조회 대상] orderId={}, escrowId={}, amount={}, reason={}",
+                            payment.getOrderId(), escrow.getHoldId(), totalAmount, unconfirmed.reason());
                 }
             }
 
@@ -538,4 +546,22 @@ public class PaymentService {
         public Long getBuyerId() { return buyerId; }
         public Long getSellerId() { return sellerId; }
     }
+
+    /**
+     * 에스크로 입금이 거절돼 토스 결제를 되돌린다.
+     *
+     * <p>입금이 거절된 것이 확정일 때만 부른다. 입금 결과가 미확정일 때 부르면
+     * 실제로는 옮겨진 돈을 고객에게 돌려주고 에스크로 계좌에는 남기게 된다.
+     */
+    private void cancelTossPaymentForFailedDeposit(Payment payment, String paymentKey, String reason) {
+        try {
+            log.info("[에스크로 입금 실패 - Toss 결제 자동 취소 시도] orderId={}", payment.getOrderId());
+            tossClient.cancel(paymentKey, reason);
+            log.info("[Toss 결제 취소 완료] orderId={}", payment.getOrderId());
+        } catch (Exception cancelEx) {
+            log.error("[Toss 결제 취소 실패 - 수동 처리 필요] orderId={}, paymentKey={}",
+                    payment.getOrderId(), paymentKey, cancelEx);
+        }
+    }
+
 }

--- a/backend/src/main/java/com/joying/rental/domain/RentalCancel.java
+++ b/backend/src/main/java/com/joying/rental/domain/RentalCancel.java
@@ -73,6 +73,14 @@ public class RentalCancel {
     @Column(name = "expires_at")
     private Timestamp expiresAt;
 
+    @Comment("차용자 환불 거래고유번호. 있으면 이미 나간 것이므로 다시 보내지 않는다")
+    @Column(name = "renter_refund_tx_no")
+    private String renterRefundTxNo;
+
+    @Comment("대여자 보증금 분배 거래고유번호. 있으면 이미 나간 것이므로 다시 보내지 않는다")
+    @Column(name = "lender_share_tx_no")
+    private String lenderShareTxNo;
+
     @Comment("취소 거래 완료 일시")
     @Column(name = "created_at", nullable = false)
     private Timestamp createdAt;
@@ -168,6 +176,36 @@ public class RentalCancel {
     /**
      * 양측 승인 여부
      */
+    /**
+     * 차용자 환불이 성공으로 확정됐다. 거래고유번호를 남긴다.
+     *
+     * <p>이 번호가 남아 있으면 이미 나간 돈이다. 환불을 다시 돌려도 이 단계는 건너뛴다.
+     */
+    public void markRenterRefundSent(String transactionUniqueNo) {
+        this.renterRefundTxNo = transactionUniqueNo;
+    }
+
+    /**
+     * 대여자 보증금 분배가 성공으로 확정됐다. 거래고유번호를 남긴다.
+     */
+    public void markLenderShareSent(String transactionUniqueNo) {
+        this.lenderShareTxNo = transactionUniqueNo;
+    }
+
+    /**
+     * 차용자 환불이 이미 나갔는지. 참이면 다시 보내면 안 된다.
+     */
+    public boolean isRenterRefundSent() {
+        return this.renterRefundTxNo != null;
+    }
+
+    /**
+     * 대여자 보증금 분배가 이미 나갔는지. 참이면 다시 보내면 안 된다.
+     */
+    public boolean isLenderShareSent() {
+        return this.lenderShareTxNo != null;
+    }
+
     public boolean isBothApproved() {
         return status == CancelStatus.APPROVED;
     }

--- a/backend/src/main/java/com/joying/rental/service/RentalService.java
+++ b/backend/src/main/java/com/joying/rental/service/RentalService.java
@@ -1,5 +1,6 @@
 package com.joying.rental.service;
 
+import com.joying.ssafy.dto.TransferOutcome;
 import com.joying.escrow.domain.Status;
 import com.joying.file.component.FileUrlResolver;
 import com.joying.file.domain.File;
@@ -876,34 +877,58 @@ public class RentalService {
             String escrowUserKey = financeApiProperties.getEscrow().getUserKey();
 
             // 5-5. SSAFY 금융망으로 환불 분배
-            try {
-                // 대여료 + 차용자 보증금 몫 → 차용자에게 환불
+            //
+            // 송금 두 건이 순차로 나간다. 예전에는 뒤엣것이 실패하면 예외를 던져 트랜잭션을
+            // 되돌렸는데, 롤백은 DB만 되돌리고 이미 나간 돈은 되돌리지 못한다. 그 상태로
+            // 다시 돌리면 차용자에게 환불이 한 번 더 나갔다.
+            //
+            // 확정된 송금은 거래고유번호를 남겨 두고, 다시 돌 때 그 단계를 건너뛴다.
+            // 확정한 뒤에는 예외를 던지지 않는다. 던지면 방금 남긴 기록까지 같이 사라진다.
+
+            // 대여료 + 차용자 보증금 몫 → 차용자에게 환불
+            if (!cancel.isRenterRefundSent()) {
                 long renterRefundAmt = escrow.getRentalFee() + cancel.getDepositRenterAmt();
-                String renterTxNo = financeApiService.transferMoney(
+                TransferOutcome outcome = financeApiService.transferMoney(
                         escrowAccountNo,
                         renterAccount.getAccountNo(),
                         renterRefundAmt,
                         "Joying 취소 환불 (대여료+보증금)",
                         escrowUserKey
                 );
-                log.info("[차용자 환불 완료] rentalHisId={}, txNo={}, amount={}, to={}",
-                        rentalHisId, renterTxNo, renterRefundAmt, renterAccount.getAccountNo());
 
-                // 대여자 보증금 몫 → 대여자에게 지급
-                if (cancel.getDepositOwnerAmt() > 0) {
-                    String lenderTxNo = financeApiService.transferMoney(
-                            escrowAccountNo,
-                            lenderAccount.getAccountNo(),
-                            cancel.getDepositOwnerAmt().longValue(),
-                            "Joying 취소 보증금 분배",
-                            escrowUserKey
-                    );
-                    log.info("[대여자 보증금 분배 완료] rentalHisId={}, txNo={}, amount={}, to={}",
-                            rentalHisId, lenderTxNo, cancel.getDepositOwnerAmt(), lenderAccount.getAccountNo());
+                if (outcome instanceof TransferOutcome.Succeeded succeeded) {
+                    cancel.markRenterRefundSent(succeeded.transactionUniqueNo());
+                    log.info("[차용자 환불 완료] rentalHisId={}, txNo={}, amount={}, to={}",
+                            rentalHisId, succeeded.transactionUniqueNo(), renterRefundAmt,
+                            renterAccount.getAccountNo());
+                } else {
+                    log.error("[차용자 환불 미완료 - 환불 중단] rentalHisId={}, outcome={}",
+                            rentalHisId, outcome);
+                    return convertToCancelResponse(cancel);
                 }
-            } catch (Exception e) {
-                log.error("[SSAFY 금융망 환불 실패] rentalHisId={}", rentalHisId, e);
-                throw new IllegalStateException("환불 처리 중 오류가 발생했습니다", e);
+            }
+
+            // 대여자 보증금 몫 → 대여자에게 지급
+            if (cancel.getDepositOwnerAmt() > 0 && !cancel.isLenderShareSent()) {
+                TransferOutcome outcome = financeApiService.transferMoney(
+                        escrowAccountNo,
+                        lenderAccount.getAccountNo(),
+                        cancel.getDepositOwnerAmt().longValue(),
+                        "Joying 취소 보증금 분배",
+                        escrowUserKey
+                );
+
+                if (outcome instanceof TransferOutcome.Succeeded succeeded) {
+                    cancel.markLenderShareSent(succeeded.transactionUniqueNo());
+                    log.info("[대여자 보증금 분배 완료] rentalHisId={}, txNo={}, amount={}, to={}",
+                            rentalHisId, succeeded.transactionUniqueNo(),
+                            cancel.getDepositOwnerAmt(), lenderAccount.getAccountNo());
+                } else {
+                    // 차용자 환불은 이미 나갔고 그 기록이 남아 있다. 다시 돌리면 여기서부터 이어간다.
+                    log.error("[대여자 보증금 분배 미완료 - 환불 중단] rentalHisId={}, outcome={}",
+                            rentalHisId, outcome);
+                    return convertToCancelResponse(cancel);
+                }
             }
 
             // 5-6. Escrow 상태 변경

--- a/backend/src/main/java/com/joying/ssafy/dto/InquireTransactionHistoryListRequest.java
+++ b/backend/src/main/java/com/joying/ssafy/dto/InquireTransactionHistoryListRequest.java
@@ -1,0 +1,44 @@
+package com.joying.ssafy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 계좌거래내역조회(목록) 요청.
+ *
+ * <p>단건 조회는 거래고유번호가 있어야 한다. 송금 결과가 미확정으로 남은 건은 그 번호를
+ * 받지 못했으므로 단건으로는 확인할 수 없다. 그래서 계좌의 기간별 목록을 받아
+ * 거래 요약에 심어 둔 주문번호로 찾는다.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InquireTransactionHistoryListRequest {
+
+	@JsonProperty("Header")
+	private SsafyApiHeader header;
+
+	@JsonProperty("accountNo")
+	private String accountNo;
+
+	/** yyyyMMdd */
+	@JsonProperty("startDate")
+	private String startDate;
+
+	/** yyyyMMdd */
+	@JsonProperty("endDate")
+	private String endDate;
+
+	/** A 전체, M 입금, D 출금 */
+	@JsonProperty("transactionType")
+	private String transactionType;
+
+	/** ASC 오름차순, DESC 내림차순 */
+	@JsonProperty("orderByType")
+	private String orderByType;
+}

--- a/backend/src/main/java/com/joying/ssafy/dto/InquireTransactionHistoryListResponse.java
+++ b/backend/src/main/java/com/joying/ssafy/dto/InquireTransactionHistoryListResponse.java
@@ -1,0 +1,42 @@
+package com.joying.ssafy.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 계좌거래내역조회(목록) 응답.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InquireTransactionHistoryListResponse {
+
+	@JsonProperty("Header")
+	private SsafyApiHeader header;
+
+	@JsonProperty("REC")
+	private TransactionListRec rec;
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class TransactionListRec {
+
+		@JsonProperty("totalCount")
+		private String totalCount;
+
+		@JsonProperty("list")
+		private List<InquireTransactionHistoryResponse.TransactionRec> list;
+	}
+}

--- a/backend/src/main/java/com/joying/ssafy/dto/TransferOutcome.java
+++ b/backend/src/main/java/com/joying/ssafy/dto/TransferOutcome.java
@@ -1,0 +1,48 @@
+package com.joying.ssafy.dto;
+
+/**
+ * 금융망 입금·송금 호출의 결과.
+ *
+ * <p>돈을 옮기는 호출은 성공과 실패 둘로 나눌 수 없다. 요청을 보낸 뒤 응답을 받지 못하면
+ * 돈이 옮겨졌는지 아닌지를 우리는 모른다. 이 상태를 실패로 적으면 실제로 옮겨진 돈이
+ * 장부에서 사라지고, 성공으로 적으면 옮겨지지 않은 돈이 장부에 생긴다.
+ *
+ * <p>그래서 결과를 셋으로 둔다. 금융망이 확정해 준 것만 확정하고, 모르는 것은 모른다고 남긴다.
+ * 미확정을 받은 쪽은 되돌리지 말고 그대로 두었다가 거래고유번호로 다시 물어 확정해야 한다.
+ */
+public sealed interface TransferOutcome {
+
+	/**
+	 * 금융망이 성공을 확정해 응답했다. 돈이 옮겨졌다.
+	 */
+	record Succeeded(String transactionUniqueNo) implements TransferOutcome {
+	}
+
+	/**
+	 * 금융망이 요청을 받고 거절했다. 돈은 옮겨지지 않았다.
+	 */
+	record Rejected(String responseCode, String responseMessage) implements TransferOutcome {
+	}
+
+	/**
+	 * 응답을 받지 못했거나 해석할 수 없다. 돈이 옮겨졌는지 알 수 없다.
+	 */
+	record Unconfirmed(String reason) implements TransferOutcome {
+	}
+
+	default boolean isSucceeded() {
+		return this instanceof Succeeded;
+	}
+
+	default boolean isUnconfirmed() {
+		return this instanceof Unconfirmed;
+	}
+
+	/**
+	 * 성공했을 때의 거래고유번호. 성공이 아니면 null.
+	 * 미확정 건을 나중에 재조회할 때 이 번호가 열쇠가 되므로, 받은 즉시 저장해야 한다.
+	 */
+	default String transactionUniqueNoOrNull() {
+		return this instanceof Succeeded s ? s.transactionUniqueNo() : null;
+	}
+}

--- a/backend/src/main/java/com/joying/ssafy/service/FinanceApiService.java
+++ b/backend/src/main/java/com/joying/ssafy/service/FinanceApiService.java
@@ -27,7 +27,7 @@ import java.util.Map;
 public class FinanceApiService {
 
 	private final FinanceApiProperties financeApiProperties;
-	private final RestTemplate restTemplate = new RestTemplate();
+	private final RestTemplate financeApiRestTemplate;
 
 	/**
 	 * SSAFY 금융망 회원 조회
@@ -52,7 +52,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<MemberSearchRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<MemberRegisterResponse> response = restTemplate.postForEntity(
+			ResponseEntity<MemberRegisterResponse> response = financeApiRestTemplate.postForEntity(
 				url,
 				entity,
 				MemberRegisterResponse.class
@@ -100,7 +100,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<MemberRegisterRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<MemberRegisterResponse> response = restTemplate.postForEntity(
+			ResponseEntity<MemberRegisterResponse> response = financeApiRestTemplate.postForEntity(
 				url,
 				entity,
 				MemberRegisterResponse.class
@@ -184,7 +184,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<OpenAccountAuthRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<OpenAccountAuthResponse> response = restTemplate.postForEntity(
+			ResponseEntity<OpenAccountAuthResponse> response = financeApiRestTemplate.postForEntity(
 				financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/accountAuth/" + apiName,
 				entity,
 				OpenAccountAuthResponse.class
@@ -254,7 +254,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<CheckAuthCodeRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<CheckAuthCodeResponse> response = restTemplate.postForEntity(
+			ResponseEntity<CheckAuthCodeResponse> response = financeApiRestTemplate.postForEntity(
 				financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/accountAuth/" + apiName,
 				entity,
 				CheckAuthCodeResponse.class
@@ -329,7 +329,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<InquireDemandDepositListRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<InquireDemandDepositListResponse> response = restTemplate.postForEntity(
+			ResponseEntity<InquireDemandDepositListResponse> response = financeApiRestTemplate.postForEntity(
 				requestUrl,
 				entity,
 				InquireDemandDepositListResponse.class
@@ -401,7 +401,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<InquireTransactionHistoryRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<InquireTransactionHistoryResponse> response = restTemplate.postForEntity(
+			ResponseEntity<InquireTransactionHistoryResponse> response = financeApiRestTemplate.postForEntity(
 				financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/demandDeposit/" + apiName,
 				entity,
 				InquireTransactionHistoryResponse.class
@@ -472,7 +472,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<CreateDemandDepositAccountRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<CreateDemandDepositAccountResponse> response = restTemplate.postForEntity(
+			ResponseEntity<CreateDemandDepositAccountResponse> response = financeApiRestTemplate.postForEntity(
 				financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/demandDeposit/" + apiName,
 				entity,
 				CreateDemandDepositAccountResponse.class
@@ -518,7 +518,7 @@ public class FinanceApiService {
 	 * @param userKey             계좌 사용자 KEY (에스크로 계좌 userKey)
 	 * @return 거래 고유번호
 	 */
-	public String depositMoney(
+	public TransferOutcome depositMoney(
 			String accountNo,
 			Long transactionBalance,
 			String transactionSummary,
@@ -549,44 +549,92 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, headers);
 
-			// Object로 받기
-			Object responseObj = restTemplate.postForObject(
+			Object responseObj = financeApiRestTemplate.postForObject(
 					financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/demandDeposit/" + apiName,
 					entity,
 					Object.class
 			);
 
-			if (responseObj == null) {
-				log.error("계좌 입금 응답이 null입니다");
-				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-			}
+			return classifyTransferResponse("계좌 입금", responseObj);
 
-			if (responseObj instanceof Map) {
-				Map responseBody = (Map) responseObj;
+		} catch (HttpClientErrorException e) {
+			// 4xx는 금융망이 요청을 받고 거절한 것이다. 돈은 옮겨지지 않았다.
+			log.warn("계좌 입금 거절: accountNo={}, status={}, body={}",
+					accountNo, e.getStatusCode(), e.getResponseBodyAsString());
+			return new TransferOutcome.Rejected(
+					e.getStatusCode().toString(), e.getResponseBodyAsString());
 
-				Map headerMap = (Map) responseBody.get("Header");
-				if (headerMap == null || !"H0000".equals(headerMap.get("responseCode"))) {
-					log.error("계좌 입금 실패: {}", headerMap);
-					throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-				}
-
-				Map recMap = (Map) responseBody.get("REC");
-				String transactionUniqueNo = (String) recMap.get("transactionUniqueNo");
-
-				log.info("계좌 입금 성공: transactionUniqueNo={}", transactionUniqueNo);
-				return transactionUniqueNo;
-			}
-
-			// 리스트 응답 또는 기타 처리
-			log.error("계좌 입금 실패(알 수 없는 응답): {}", responseObj);
-			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-
-		} catch (BusinessException e) {
-			throw e;
 		} catch (Exception e) {
-			log.error("계좌 입금 API 호출 중 오류 발생", e);
-			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+			// 타임아웃, 연결 실패, 5xx는 입금이 됐는지 알 수 없다.
+			// 연결 타임아웃만 "보내지 않았다"로 가를 수도 있으나, 클라이언트 구현에 따라
+			// 연결 타임아웃과 읽기 타임아웃이 같은 예외로 올라와 안전하게 가르기 어렵다.
+			// 미확정으로 잘못 분류하면 재조회 한 번이 더 들고, 확정 실패로 잘못 분류하면
+			// 이미 옮겨진 돈을 장부에서 지운다. 그래서 모르는 것은 전부 미확정으로 둔다.
+			log.error("계좌 입금 결과 미확정: accountNo={}, 금액={}",
+					accountNo, transactionBalance, e);
+			return new TransferOutcome.Unconfirmed(
+					e.getClass().getSimpleName() + ": " + e.getMessage());
 		}
+	}
+
+	/**
+	 * 금융망 입금·송금 응답을 확정 결과로 옮긴다.
+	 *
+	 * <p>헤더의 응답 코드가 H0000일 때만 성공으로 본다. 그 밖의 코드는 금융망이 요청을 받고
+	 * 거절한 것이므로 확정 실패로 본다. 응답이 비었거나 모양이 예상과 다르면 무슨 일이
+	 * 있었는지 알 수 없으므로 미확정으로 둔다.
+	 *
+	 * <p>H0000이 아닌 코드 안에도 성격이 다른 것이 섞여 있을 수 있다. 코드별 분류는 아직
+	 * 하지 않았고, 그때까지는 전부 확정 실패로 둔다.
+	 */
+	private TransferOutcome classifyTransferResponse(String what, Object responseObj) {
+		if (responseObj == null) {
+			log.error("{} 응답이 null입니다", what);
+			return new TransferOutcome.Unconfirmed("응답 없음");
+		}
+
+		if (!(responseObj instanceof Map<?, ?> responseBody)) {
+			log.error("{} 응답 모양을 알 수 없습니다: {}", what, responseObj);
+			return new TransferOutcome.Unconfirmed("응답 모양 불명");
+		}
+
+		if (!(responseBody.get("Header") instanceof Map<?, ?> headerMap)) {
+			log.error("{} 응답에 Header가 없습니다: {}", what, responseBody);
+			return new TransferOutcome.Unconfirmed("Header 없음");
+		}
+
+		String responseCode = String.valueOf(headerMap.get("responseCode"));
+		if (!"H0000".equals(responseCode)) {
+			log.warn("{} 거절: {}", what, headerMap);
+			return new TransferOutcome.Rejected(
+					responseCode, String.valueOf(headerMap.get("responseMessage")));
+		}
+
+		Object recObj = responseBody.get("REC");
+		String transactionUniqueNo = extractTransactionUniqueNo(recObj);
+		if (transactionUniqueNo == null) {
+			// 성공 코드가 왔는데 거래고유번호가 없으면 나중에 이 건을 다시 물을 수 없다.
+			// 확정할 근거가 모자라므로 미확정으로 둔다.
+			log.error("{} 성공 응답에 거래고유번호가 없습니다: {}", what, recObj);
+			return new TransferOutcome.Unconfirmed("거래고유번호 없음");
+		}
+
+		log.info("{} 성공: transactionUniqueNo={}", what, transactionUniqueNo);
+		return new TransferOutcome.Succeeded(transactionUniqueNo);
+	}
+
+	/**
+	 * REC는 단건이면 Map, 다건이면 List로 온다. 둘 다에서 거래고유번호를 꺼낸다.
+	 */
+	private String extractTransactionUniqueNo(Object recObj) {
+		if (recObj instanceof Map<?, ?> recMap) {
+			Object v = recMap.get("transactionUniqueNo");
+			return v == null ? null : String.valueOf(v);
+		}
+		if (recObj instanceof List<?> list && !list.isEmpty()) {
+			return extractTransactionUniqueNo(list.get(0));
+		}
+		return null;
 	}
 
 
@@ -624,7 +672,7 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<InquireDemandDepositAccountHolderNameRequest> entity = new HttpEntity<>(request, headers);
 
-			ResponseEntity<InquireDemandDepositAccountHolderNameResponse> response = restTemplate.postForEntity(
+			ResponseEntity<InquireDemandDepositAccountHolderNameResponse> response = financeApiRestTemplate.postForEntity(
 				financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/demandDeposit/" + apiName,
 				entity,
 				InquireDemandDepositAccountHolderNameResponse.class
@@ -670,13 +718,14 @@ public class FinanceApiService {
 	 * @param withdrawalUserKey    출금 계좌 사용자 KEY (Joying 중개계좌 userKey)
 	 * @return 거래 고유번호
 	 */
-	public String transferMoney(
+	public TransferOutcome transferMoney(
 			String withdrawalAccountNo,
 			String depositAccountNo,
 			Long transactionBalance,
 			String transactionSummary,
 			String withdrawalUserKey
 	) {
+
 
 		String apiName = "updateDemandDepositAccountTransfer";
 
@@ -705,66 +754,105 @@ public class FinanceApiService {
 			headers.setContentType(MediaType.APPLICATION_JSON);
 			HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request, headers);
 
-			Object responseObj = restTemplate.postForObject(
+			Object responseObj = financeApiRestTemplate.postForObject(
 					financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/demandDeposit/" + apiName,
 					entity,
 					Object.class
 			);
 
-			if (responseObj == null) {
-				log.error("계좌 송금 응답이 null입니다");
+			return classifyTransferResponse("계좌 송금", responseObj);
+
+		} catch (HttpClientErrorException e) {
+			// 4xx는 금융망이 요청을 받고 거절한 것이다. 돈은 옮겨지지 않았다.
+			log.warn("계좌 송금 거절: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+			return new TransferOutcome.Rejected(
+					e.getStatusCode().toString(), e.getResponseBodyAsString());
+
+		} catch (Exception e) {
+			// 타임아웃, 연결 실패, 5xx는 송금이 나갔는지 알 수 없다.
+			// 여기서 실패로 확정하고 되돌리면, 실제로 나간 돈을 장부에서 지운다.
+			log.error("계좌 송금 결과 미확정", e);
+			return new TransferOutcome.Unconfirmed(
+					e.getClass().getSimpleName() + ": " + e.getMessage());
+		}
+	}
+
+	/**
+	 * 계좌거래내역조회(목록).
+	 *
+	 * <p>송금 결과가 미확정으로 남은 건은 거래고유번호를 받지 못해 단건 조회로는 확인할 수
+	 * 없다. 이 조회로 계좌의 기간별 거래를 받아, 거래 요약에 심어 둔 주문번호로 찾는다.
+	 *
+	 * <p>조회 자체가 실패하면 빈 목록이 아니라 예외를 던진다. 빈 목록을 돌려주면
+	 * 부르는 쪽이 "거래가 없었다"로 읽어 미확정 건을 실패로 확정해 버린다.
+	 *
+	 * @param accountNo 조회할 계좌번호
+	 * @param startDate 조회 시작일 yyyyMMdd
+	 * @param endDate   조회 종료일 yyyyMMdd
+	 * @param userKey   계좌 사용자 KEY
+	 * @return 기간 내 거래 목록. 거래가 없으면 빈 목록
+	 */
+	public List<InquireTransactionHistoryResponse.TransactionRec> inquireTransactionHistoryList(
+			String accountNo,
+			String startDate,
+			String endDate,
+			String userKey
+	) {
+		String apiName = "inquireTransactionHistoryList";
+
+		SsafyApiHeader header = SsafyApiHeader.createRequestHeaderWithUserKey(
+				apiName,
+				apiName,
+				financeApiProperties.getApiKey(),
+				userKey,
+				financeApiProperties.getInstitutionCode(),
+				financeApiProperties.getFintechAppNo()
+		);
+
+		InquireTransactionHistoryListRequest request = InquireTransactionHistoryListRequest.builder()
+				.header(header)
+				.accountNo(accountNo)
+				.startDate(startDate)
+				.endDate(endDate)
+				.transactionType("A")
+				.orderByType("DESC")
+				.build();
+
+		log.info("계좌거래내역 목록 조회 요청: accountNo={}, {}~{}", accountNo, startDate, endDate);
+
+		try {
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			HttpEntity<InquireTransactionHistoryListRequest> entity = new HttpEntity<>(request, headers);
+
+			ResponseEntity<InquireTransactionHistoryListResponse> response =
+					financeApiRestTemplate.postForEntity(
+							financeApiProperties.getBaseUrl() + "/ssafy/api/v1/edu/demandDeposit/" + apiName,
+							entity,
+							InquireTransactionHistoryListResponse.class
+					);
+
+			InquireTransactionHistoryListResponse body = response.getBody();
+			if (body == null || body.getHeader() == null
+					|| !"H0000".equals(body.getHeader().getResponseCode())) {
+				log.error("계좌거래내역 목록 조회 실패: accountNo={}, body={}", accountNo, body);
 				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
 			}
 
-			// 성공/실패 공통: Response는 Map으로 온다
-			if (!(responseObj instanceof Map)) {
-				log.error("계좌 송금 실패(전체 응답 타입이 Map이 아님): {}", responseObj);
-				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+			if (body.getRec() == null || body.getRec().getList() == null) {
+				return List.of();
 			}
 
-			Map responseBody = (Map) responseObj;
-
-			Map headerMap = (Map) responseBody.get("Header");
-			if (headerMap == null || !"H0000".equals(headerMap.get("responseCode"))) {
-				log.error("계좌 송금 실패(Header 오류): {}", headerMap);
-				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-			}
-
-			Object recObj = responseBody.get("REC");
-
-			/**
-			 * 실패: REC = Map (errorCode, errorMessage)
-			 */
-			if (recObj instanceof Map) {
-				log.error("계좌 송금 실패(REC=Map 오류): {}", recObj);
-				throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-			}
-
-			/**
-			 * 성공: REC = List (출금/입금 2건)
-			 */
-			if (recObj instanceof List<?> list) {
-				if (list.isEmpty()) {
-					log.error("REC 리스트가 비어 있습니다: {}", list);
-					throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-				}
-
-				Map firstRecord = (Map) list.get(0);
-				String transactionUniqueNo = (String) firstRecord.get("transactionUniqueNo");
-
-				log.info("계좌 송금 성공: transactionUniqueNo={}", transactionUniqueNo);
-				return transactionUniqueNo;
-			}
-
-			// 알 수 없는 구조
-			log.error("계좌 송금 실패(REC 타입 알 수 없음): {}", recObj);
-			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+			log.info("계좌거래내역 목록 조회 성공: accountNo={}, 건수={}",
+					accountNo, body.getRec().getList().size());
+			return body.getRec().getList();
 
 		} catch (BusinessException e) {
 			throw e;
 		} catch (Exception e) {
-			log.error("계좌 송금 API 호출 중 오류 발생", e);
+			log.error("계좌거래내역 목록 조회 중 오류 발생: accountNo={}", accountNo, e);
 			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
+
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -132,9 +132,16 @@ app.file.public-base-url=${CLOUDFLARE_R2_PUBLIC_BASE_URL}
 ssafy.finance.base-url=${SSAFY_FINANCE_BASE_URL:https://finopenapi.ssafy.io}
 ssafy.finance.api-key=${SSAFY_FINANCE_API_KEY}
 
+# 금융망 호출 타임아웃. 읽기 타임아웃이 지나면 송금 성공 여부를 알 수 없는 상태가 된다.
+ssafy.finance.connect-timeout=${SSAFY_FINANCE_CONNECT_TIMEOUT:2s}
+ssafy.finance.read-timeout=${SSAFY_FINANCE_READ_TIMEOUT:5s}
+
 # Joying 중개 계좌 (에스크로)
 ssafy.finance.escrow.account-no=${SSAFY_ESCROW_ACCOUNT_NO:0015555555555555}
 ssafy.finance.escrow.user-key=${SSAFY_ESCROW_USER_KEY}
+# 에스크로 입금이 미확정으로 남은 건을 금융망에 다시 물어 확정하는 주기
+joying.escrow.deposit-recovery.interval-ms=${ESCROW_DEPOSIT_RECOVERY_INTERVAL_MS:60000}
+
 
 # -------------------------------------
 # Cookie 보안 설정

--- a/backend/src/test/java/com/joying/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/joying/TestcontainersConfiguration.java
@@ -1,0 +1,27 @@
+package com.joying;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * 테스트용 Redis 컨테이너.
+ *
+ * <p>{@link JoyingApplicationTests}가 참조하지만 저장소에 없어 테스트 소스가 컴파일되지
+ * 않던 클래스다. 컨테이너는 JVM당 한 번만 띄우고 테스트가 끝나면 Ryuk이 정리한다.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class TestcontainersConfiguration {
+
+	private static final GenericContainer<?> REDIS_CONTAINER =
+		new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+			.withExposedPorts(6379);
+
+	static {
+		REDIS_CONTAINER.start();
+	}
+
+	public static GenericContainer<?> getRedisContainer() {
+		return REDIS_CONTAINER;
+	}
+}

--- a/backend/src/test/java/com/joying/escrow/EscrowDepositRecoveryTest.java
+++ b/backend/src/test/java/com/joying/escrow/EscrowDepositRecoveryTest.java
@@ -1,0 +1,119 @@
+package com.joying.escrow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.joying.common.config.ssafy.FinanceApiProperties;
+import com.joying.escrow.domain.Escrow;
+import com.joying.escrow.domain.Status;
+import com.joying.escrow.repository.EscrowRepository;
+import com.joying.escrow.service.EscrowDepositRecoveryService;
+import com.joying.payment.domain.Payment;
+import com.joying.ssafy.dto.InquireTransactionHistoryResponse.TransactionRec;
+import com.joying.ssafy.service.FinanceApiService;
+
+/**
+ * 미확정 입금을 다시 물어 확정하는 작업.
+ *
+ * <p>가장 중요한 규칙은 "확정할 근거가 없으면 확정하지 않는다"이다. 조회가 실패한 것을
+ * 거래가 없었던 것으로 읽으면, 실제로 들어간 돈을 장부에서 지우게 된다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EscrowDepositRecoveryTest {
+
+	@Mock
+	EscrowRepository escrowRepository;
+
+	@Mock
+	FinanceApiService financeApiService;
+
+	@Mock(strictness = Mock.Strictness.LENIENT)
+	FinanceApiProperties financeApiProperties;
+
+	@Mock(strictness = Mock.Strictness.LENIENT)
+	Payment payment;
+
+	@InjectMocks
+	EscrowDepositRecoveryService recoveryService;
+
+	private Escrow unconfirmedEscrow;
+
+	@BeforeEach
+	void setUp() {
+		FinanceApiProperties.Escrow escrowProps = new FinanceApiProperties.Escrow();
+		escrowProps.setAccountNo("0015555555555555");
+		escrowProps.setUserKey("escrow-user-key");
+		given(financeApiProperties.getEscrow()).willReturn(escrowProps);
+
+		given(payment.getOrderId()).willReturn("ORDER-1");
+		unconfirmedEscrow = Escrow.createPending(null, payment, 30_000, 50_000);
+	}
+
+	private TransactionRec tx(String txNo, String summary) {
+		return TransactionRec.builder()
+			.transactionUniqueNo(txNo)
+			.transactionSummary(summary)
+			.build();
+	}
+
+	@Test
+	@DisplayName("거래 요약에서 주문번호를 찾으면 입금을 확정한다")
+	void confirmsWhenTransactionFound() {
+		given(escrowRepository.findByStatus(Status.PENDING)).willReturn(List.of(unconfirmedEscrow));
+		given(financeApiService.inquireTransactionHistoryList(anyString(), anyString(), anyString(), anyString()))
+			.willReturn(List.of(tx("TX-9", "Toss 결제 에스크로 입금 (orderId: ORDER-1)")));
+
+		recoveryService.confirmUnconfirmedDeposits();
+
+		assertThat(unconfirmedEscrow.getStatus()).isEqualTo(Status.HELD);
+		assertThat(unconfirmedEscrow.getDepositTxNo()).isEqualTo("TX-9");
+	}
+
+	@Test
+	@DisplayName("조회가 실패하면 아무것도 확정하지 않는다. 실패를 거래 없음으로 읽으면 안 된다")
+	void confirmsNothingWhenQueryFails() {
+		given(escrowRepository.findByStatus(Status.PENDING)).willReturn(List.of(unconfirmedEscrow));
+		given(financeApiService.inquireTransactionHistoryList(anyString(), anyString(), anyString(), anyString()))
+			.willThrow(new RuntimeException("금융망 조회 실패"));
+
+		recoveryService.confirmUnconfirmedDeposits();
+
+		assertThat(unconfirmedEscrow.getStatus()).isEqualTo(Status.PENDING);
+		assertThat(unconfirmedEscrow.getDepositTxNo()).isNull();
+	}
+
+	@Test
+	@DisplayName("거래를 못 찾아도 실패로 확정하지 않고 미확정으로 남긴다")
+	void keepsPendingWhenNotFoundYet() {
+		given(escrowRepository.findByStatus(Status.PENDING)).willReturn(List.of(unconfirmedEscrow));
+		given(financeApiService.inquireTransactionHistoryList(anyString(), anyString(), anyString(), anyString()))
+			.willReturn(List.of(tx("TX-OTHER", "Toss 결제 에스크로 입금 (orderId: ORDER-999)")));
+
+		recoveryService.confirmUnconfirmedDeposits();
+
+		assertThat(unconfirmedEscrow.getStatus()).isEqualTo(Status.PENDING);
+	}
+
+	@Test
+	@DisplayName("미확정 건이 없으면 금융망을 부르지 않는다")
+	void doesNotCallFinanceApiWhenNothingPending() {
+		given(escrowRepository.findByStatus(Status.PENDING)).willReturn(List.of());
+
+		recoveryService.confirmUnconfirmedDeposits();
+
+		org.mockito.Mockito.verify(financeApiService, org.mockito.Mockito.never())
+			.inquireTransactionHistoryList(any(), any(), any(), any());
+	}
+}

--- a/backend/src/test/java/com/joying/escrow/EscrowSettlementResumeTest.java
+++ b/backend/src/test/java/com/joying/escrow/EscrowSettlementResumeTest.java
@@ -1,0 +1,86 @@
+package com.joying.escrow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.joying.escrow.domain.Escrow;
+
+/**
+ * 정산 송금이 중간에 멈춘 뒤 다시 돌 때 이미 나간 돈을 또 보내지 않는지 확인한다.
+ *
+ * <p>예전에는 대여료 지급이 성공한 뒤 보증금 반환이 실패하면 예외를 던져 트랜잭션을
+ * 되돌렸다. 롤백은 DB만 되돌리고 이미 나간 대여료는 되돌리지 못하므로, 정산을 다시
+ * 돌리면 대여료가 한 번 더 나갔다. 거래고유번호를 남겨 그 단계를 건너뛰게 한 것이
+ * 이 테스트가 지키는 규칙이다.
+ */
+class EscrowSettlementResumeTest {
+
+	private Escrow newEscrow() {
+		return Escrow.createPending(null, null, 30_000, 50_000);
+	}
+
+	@Test
+	@DisplayName("입금 확정 전에는 PENDING이고, 확정되면 거래고유번호가 남고 HELD가 된다")
+	void depositConfirmationMovesToHeld() {
+		Escrow escrow = newEscrow();
+
+		assertThat(escrow.isDepositUnconfirmed()).isTrue();
+
+		escrow.markHeld("TX-DEPOSIT");
+
+		assertThat(escrow.isDepositUnconfirmed()).isFalse();
+		assertThat(escrow.getDepositTxNo()).isEqualTo("TX-DEPOSIT");
+	}
+
+	@Test
+	@DisplayName("대여료가 나가기 전에는 보낼 대상이고, 확정되면 다시 보내지 않는다")
+	void rentalFeeIsSentOnlyOnce() {
+		Escrow escrow = newEscrow();
+
+		assertThat(escrow.isRentalFeeSent()).isFalse();
+
+		escrow.markRentalFeeSent("TX-FEE", Timestamp.from(Instant.now()));
+
+		assertThat(escrow.isRentalFeeSent()).isTrue();
+		assertThat(escrow.getRentalFeeTxNo()).isEqualTo("TX-FEE");
+		assertThat(escrow.getRentalFeeReleasedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("대여료만 나가고 보증금이 미확정으로 멈춰도 대여료 기록은 남는다")
+	void partialSettlementKeepsWhatAlreadyWentOut() {
+		Escrow escrow = newEscrow();
+		escrow.markHeld("TX-DEPOSIT");
+
+		// 1단계는 확정, 2단계는 미확정으로 멈춘 상태
+		escrow.markRentalFeeSent("TX-FEE", Timestamp.from(Instant.now()));
+
+		assertThat(escrow.isRentalFeeSent()).isTrue();
+		assertThat(escrow.isDepositReturned()).isFalse();
+
+		// 다시 돌리면 대여료는 건너뛰고 보증금부터 이어간다
+		escrow.markDepositReturned("TX-RETURN", Timestamp.from(Instant.now()));
+
+		assertThat(escrow.getRentalFeeTxNo()).isEqualTo("TX-FEE");
+		assertThat(escrow.getDepositReturnTxNo()).isEqualTo("TX-RETURN");
+	}
+
+	@Test
+	@DisplayName("입금이 확정되지 않은 에스크로는 예치로 넘어갈 수 없다")
+	void cannotHoldTwice() {
+		Escrow escrow = newEscrow();
+		escrow.markHeld("TX-DEPOSIT");
+
+		try {
+			escrow.markHeld("TX-DEPOSIT-AGAIN");
+			assertThat(false).as("두 번 예치로 넘어가면 안 된다").isTrue();
+		} catch (IllegalStateException expected) {
+			assertThat(escrow.getDepositTxNo()).isEqualTo("TX-DEPOSIT");
+		}
+	}
+}

--- a/backend/src/test/java/com/joying/ssafy/service/FinanceApiServiceDepositTest.java
+++ b/backend/src/test/java/com/joying/ssafy/service/FinanceApiServiceDepositTest.java
@@ -1,0 +1,152 @@
+package com.joying.ssafy.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import com.joying.common.config.ssafy.FinanceApiProperties;
+import com.joying.ssafy.dto.TransferOutcome;
+
+/**
+ * 금융망 입금 결과 판정.
+ *
+ * <p>돈을 옮기는 호출은 성공과 실패 둘로 나눌 수 없다. 금융망이 확정해 준 것만 확정하고
+ * 나머지는 미확정으로 남는지를 고정한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class FinanceApiServiceDepositTest {
+
+	@Mock
+	RestTemplate financeApiRestTemplate;
+
+	@Mock(strictness = Mock.Strictness.LENIENT)
+	FinanceApiProperties financeApiProperties;
+
+	@InjectMocks
+	FinanceApiService financeApiService;
+
+	private static final String ACCOUNT_NO = "0015555555555555";
+	private static final String USER_KEY = "user-key";
+
+	private TransferOutcome deposit() {
+		return financeApiService.depositMoney(ACCOUNT_NO, 10_000L, "테스트 입금", USER_KEY);
+	}
+
+	private void givenResponse(Object body) {
+		given(financeApiProperties.getBaseUrl()).willReturn("https://finopenapi.example");
+		given(financeApiRestTemplate.postForObject(anyString(), any(), any())).willReturn(body);
+	}
+
+	private void givenThrows(Throwable t) {
+		given(financeApiProperties.getBaseUrl()).willReturn("https://finopenapi.example");
+		given(financeApiRestTemplate.postForObject(anyString(), any(), any())).willThrow(t);
+	}
+
+	@Test
+	@DisplayName("H0000과 거래고유번호가 오면 성공으로 확정한다")
+	void succeeded() {
+		givenResponse(Map.of(
+			"Header", Map.of("responseCode", "H0000", "responseMessage", "정상처리"),
+			"REC", Map.of("transactionUniqueNo", "TX-1")));
+
+		TransferOutcome outcome = deposit();
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Succeeded.class);
+		assertThat(outcome.transactionUniqueNoOrNull()).isEqualTo("TX-1");
+	}
+
+	@Test
+	@DisplayName("REC이 리스트로 와도 거래고유번호를 꺼낸다")
+	void succeededWithListRec() {
+		givenResponse(Map.of(
+			"Header", Map.of("responseCode", "H0000"),
+			"REC", List.of(Map.of("transactionUniqueNo", "TX-2"))));
+
+		assertThat(deposit().transactionUniqueNoOrNull()).isEqualTo("TX-2");
+	}
+
+	@Test
+	@DisplayName("H0000이 아닌 응답 코드는 확정 실패다. 돈은 옮겨지지 않았다")
+	void rejectedByResponseCode() {
+		givenResponse(Map.of(
+			"Header", Map.of("responseCode", "A1001", "responseMessage", "잔액 부족")));
+
+		TransferOutcome outcome = deposit();
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Rejected.class);
+		assertThat(((TransferOutcome.Rejected) outcome).responseCode()).isEqualTo("A1001");
+	}
+
+	@Test
+	@DisplayName("4xx는 금융망이 요청을 받고 거절한 것이므로 확정 실패다")
+	void rejectedByHttpStatus() {
+		givenThrows(HttpClientErrorException.create(
+			HttpStatus.BAD_REQUEST, "Bad Request", null, null, null));
+
+		assertThat(deposit()).isInstanceOf(TransferOutcome.Rejected.class);
+	}
+
+	@Test
+	@DisplayName("읽기 타임아웃은 입금 여부를 알 수 없으므로 미확정이다")
+	void unconfirmedOnReadTimeout() {
+		givenThrows(new ResourceAccessException(
+			"Read timed out", new SocketTimeoutException("Read timed out")));
+
+		TransferOutcome outcome = deposit();
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Unconfirmed.class);
+		assertThat(outcome.isUnconfirmed()).isTrue();
+	}
+
+	@Test
+	@DisplayName("응답이 비면 미확정이다")
+	void unconfirmedOnNullBody() {
+		givenResponse(null);
+
+		assertThat(deposit()).isInstanceOf(TransferOutcome.Unconfirmed.class);
+	}
+
+	@Test
+	@DisplayName("성공 코드가 와도 거래고유번호가 없으면 미확정이다. 나중에 다시 물을 열쇠가 없다")
+	void unconfirmedWhenTransactionNumberMissing() {
+		givenResponse(Map.of(
+			"Header", Map.of("responseCode", "H0000"),
+			"REC", Map.of()));
+
+		assertThat(deposit()).isInstanceOf(TransferOutcome.Unconfirmed.class);
+	}
+
+	@Test
+	@DisplayName("응답 모양을 알 수 없으면 성공으로 넘기지 않는다")
+	void unconfirmedOnUnknownShape() {
+		givenResponse("그냥 문자열");
+
+		assertThat(deposit()).isInstanceOf(TransferOutcome.Unconfirmed.class);
+	}
+
+	@Test
+	@DisplayName("타임아웃 기본값은 연결 2초, 읽기 5초다")
+	void defaultTimeouts() {
+		FinanceApiProperties actual = new FinanceApiProperties();
+
+		assertThat(actual.getConnectTimeout()).isEqualTo(Duration.ofSeconds(2));
+		assertThat(actual.getReadTimeout()).isEqualTo(Duration.ofSeconds(5));
+	}
+}


### PR DESCRIPTION
Closes #6
Base: #14 (fix/money-transfer-outcome)

거래 요약에 심어 둔 주문번호로 계좌 거래 목록에서 찾아 확정한다. 목록 조회는 없어서 새로 붙였다.

조회 실패를 거래 없음으로 읽지 않고, 못 찾았다고 실패로 확정하지도 않는다. 없다는 것을 근거로 자동 재송금하지 않는다.