### PR TITLE
feat: 돈을 옮기는 자리를 전자지갑 내부 원장으로 옮긴다

### DIFF
--- a/backend/src/main/java/com/joying/escrow/service/EscrowDepositRecoveryService.java
+++ b/backend/src/main/java/com/joying/escrow/service/EscrowDepositRecoveryService.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,12 +32,16 @@ import lombok.extern.slf4j.Slf4j;
  * 입금할 때 거래 요약에 주문번호를 심어 두었고, 계좌의 기간별 거래 목록에서 그 주문번호로
  * 찾는다. 같은 주문번호로 두 번 입금되는 일이 없으므로 이 요약이 사실상의 열쇠가 된다.
  *
+ * <p>내부 원장으로 돈을 옮길 때는 이 작업이 돌지 않는다. 커밋되거나 롤백되거나
+ * 둘뿐이라 미확정이 생기지 않기 때문이다. 외부 금융망 구현을 켤 때만 함께 켜진다.
+ *
  * <p>찾지 못했다고 해서 실패로 확정하지 않는다. 조회가 실패했을 수도 있고 금융망 반영이
  * 늦을 수도 있다. 확정할 근거가 없으면 그대로 두고 다음 주기에 다시 묻는다.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "joying.money.transfer", havingValue = "ssafy")
 public class EscrowDepositRecoveryService {
 
 	private static final DateTimeFormatter YYYYMMDD = DateTimeFormatter.ofPattern("yyyyMMdd");

--- a/backend/src/main/java/com/joying/escrow/service/EscrowService.java
+++ b/backend/src/main/java/com/joying/escrow/service/EscrowService.java
@@ -6,6 +6,7 @@ import com.joying.account.domain.Account;
 import com.joying.common.config.ssafy.FinanceApiProperties;
 import com.joying.escrow.domain.Escrow;
 import com.joying.ssafy.dto.TransferOutcome;
+import com.joying.wallet.port.MoneyTransferPort;
 import com.joying.escrow.dto.request.EscrowCreateRequest;
 import com.joying.escrow.dto.response.EscrowResponse;
 import com.joying.escrow.repository.EscrowRepository;
@@ -32,7 +33,7 @@ public class EscrowService {
     private final EscrowRepository escrowRepository;
     private final RentalHistoryRepository rentalHistoryRepository;
     private final PaymentRepository paymentRepository;
-    private final FinanceApiService financeApiService;
+    private final MoneyTransferPort moneyTransferPort;
     private final FinanceApiProperties financeApiProperties;
 
     /**
@@ -156,12 +157,11 @@ public class EscrowService {
         // 그래서 확정된 송금은 거래고유번호를 남겨 두고, 다시 돌 때 그 단계를 건너뛴다.
         // 확정한 뒤에는 예외를 던지지 않는다. 던지면 방금 남긴 기록까지 같이 사라진다.
         if (!escrow.isRentalFeeSent()) {
-            TransferOutcome outcome = financeApiService.transferMoney(
-                    escrowAccountNo,
-                    lenderAccount.getAccountNo(),
+            TransferOutcome outcome = moneyTransferPort.transferFromEscrow(
+                    lender.getMemberId(),
                     escrow.getRentalFee().longValue(),
-                    "Joying 대여료 지급",
-                    escrowUserKey
+                    "settle-fee-" + escrow.getHoldId(),
+                    "Joying 대여료 지급"
             );
 
             if (outcome instanceof TransferOutcome.Succeeded succeeded) {
@@ -179,12 +179,11 @@ public class EscrowService {
 
         // 5. SSAFY 금융망으로 보증금 반환 (Joying 중개 계좌 → 차용자)
         if (!escrow.isDepositReturned()) {
-            TransferOutcome outcome = financeApiService.transferMoney(
-                    escrowAccountNo,
-                    renterAccount.getAccountNo(),
+            TransferOutcome outcome = moneyTransferPort.transferFromEscrow(
+                    renter.getMemberId(),
                     escrow.getDepositAmount().longValue(),
-                    "Joying 보증금 반환",
-                    escrowUserKey
+                    "settle-deposit-" + escrow.getHoldId(),
+                    "Joying 보증금 반환"
             );
 
             if (outcome instanceof TransferOutcome.Succeeded succeeded) {

--- a/backend/src/main/java/com/joying/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/joying/payment/service/PaymentService.java
@@ -1,7 +1,6 @@
 package com.joying.payment.service;
 
 import com.joying.account.domain.Account;
-import com.joying.common.config.ssafy.FinanceApiProperties;
 import com.joying.member.domain.Member;
 import com.joying.member.repository.MemberRepository;
 import com.joying.payment.domain.Payment;
@@ -24,6 +23,7 @@ import com.joying.rental.domain.RentalHistory;
 import com.joying.rental.repository.RentalHistoryRepository;
 import com.joying.escrow.domain.Escrow;
 import com.joying.ssafy.dto.TransferOutcome;
+import com.joying.wallet.port.MoneyTransferPort;
 import com.joying.escrow.repository.EscrowRepository;
 import com.joying.ssafy.service.FinanceApiService;
 import lombok.RequiredArgsConstructor;
@@ -64,8 +64,7 @@ public class PaymentService {
     private final EscrowRepository escrowRepository;
     private final TossPaymentsClient tossClient;
     private final ApplicationEventPublisher eventPublisher;
-    private final FinanceApiService financeApiService;
-    private final FinanceApiProperties financeApiProperties;
+    private final MoneyTransferPort moneyTransferPort;
 
     /**
      * 1. 결제 생성 (orderId 발급)
@@ -395,23 +394,21 @@ public class PaymentService {
 
                 // 토스 결제 완료 후 Joying 에스크로 계좌로 입금 (SSAFY 금융망)
                 // 실제 돈은 토스에 있고, SSAFY 금융망에는 논리적으로만 입금
-                String escrowAccountNo = financeApiProperties.getEscrow().getAccountNo();
-                String escrowUserKey = financeApiProperties.getEscrow().getUserKey();
                 // 실제 결제 금액 = (일일요금 × 일수) + 보증금 (payment.getTotalAmount()에 저장됨)
                 long totalAmount = payment.getTotalAmount().longValue();
 
-                TransferOutcome outcome = financeApiService.depositMoney(
-                        escrowAccountNo,
+                // 주문번호를 참조로 쓴다. 같은 주문으로 두 번 불러도 돈은 한 번만 움직인다.
+                TransferOutcome outcome = moneyTransferPort.creditToEscrow(
                         totalAmount,
-                        "Toss 결제 에스크로 입금 (orderId: " + payment.getOrderId() + ")",
-                        escrowUserKey
+                        "escrow-deposit-" + payment.getOrderId(),
+                        "Toss 결제 에스크로 입금 (orderId: " + payment.getOrderId() + ")"
                 );
 
                 if (outcome instanceof TransferOutcome.Succeeded succeeded) {
                     escrow.markHeld(succeeded.transactionUniqueNo());
-                    log.info("[에스크로 계좌 입금 완료] rentalHisId={}, txNo={}, amount={}, to={}",
+                    log.info("[에스크로 적립 완료] rentalHisId={}, transferId={}, amount={}, via={}",
                             rentalHistory.getRentalHisId(), succeeded.transactionUniqueNo(),
-                            totalAmount, escrowAccountNo);
+                            totalAmount, moneyTransferPort.name());
 
                 } else if (outcome instanceof TransferOutcome.Rejected rejected) {
                     // 금융망이 요청을 받고 거절했다. 돈은 옮겨지지 않은 것이 확정이므로,

--- a/backend/src/main/java/com/joying/rental/service/RentalService.java
+++ b/backend/src/main/java/com/joying/rental/service/RentalService.java
@@ -1,6 +1,7 @@
 package com.joying.rental.service;
 
 import com.joying.ssafy.dto.TransferOutcome;
+import com.joying.wallet.port.MoneyTransferPort;
 import com.joying.escrow.domain.Status;
 import com.joying.file.component.FileUrlResolver;
 import com.joying.file.domain.File;
@@ -72,7 +73,7 @@ public class RentalService {
     private final EscrowService escrowService;
     private final PaymentRepository paymentRepository;
     private final PaymentService paymentService;
-    private final FinanceApiService financeApiService;
+    private final MoneyTransferPort moneyTransferPort;
     private final FinanceApiProperties financeApiProperties;
     private final DevModeProperties devModeProperties;
 
@@ -888,12 +889,11 @@ public class RentalService {
             // 대여료 + 차용자 보증금 몫 → 차용자에게 환불
             if (!cancel.isRenterRefundSent()) {
                 long renterRefundAmt = escrow.getRentalFee() + cancel.getDepositRenterAmt();
-                TransferOutcome outcome = financeApiService.transferMoney(
-                        escrowAccountNo,
-                        renterAccount.getAccountNo(),
+                TransferOutcome outcome = moneyTransferPort.transferFromEscrow(
+                        renter.getMemberId(),
                         renterRefundAmt,
-                        "Joying 취소 환불 (대여료+보증금)",
-                        escrowUserKey
+                        "cancel-renter-" + cancel.getCancelId(),
+                        "Joying 취소 환불 (대여료+보증금)"
                 );
 
                 if (outcome instanceof TransferOutcome.Succeeded succeeded) {
@@ -910,12 +910,11 @@ public class RentalService {
 
             // 대여자 보증금 몫 → 대여자에게 지급
             if (cancel.getDepositOwnerAmt() > 0 && !cancel.isLenderShareSent()) {
-                TransferOutcome outcome = financeApiService.transferMoney(
-                        escrowAccountNo,
-                        lenderAccount.getAccountNo(),
+                TransferOutcome outcome = moneyTransferPort.transferFromEscrow(
+                        lender.getMemberId(),
                         cancel.getDepositOwnerAmt().longValue(),
-                        "Joying 취소 보증금 분배",
-                        escrowUserKey
+                        "cancel-lender-" + cancel.getCancelId(),
+                        "Joying 취소 보증금 분배"
                 );
 
                 if (outcome instanceof TransferOutcome.Succeeded succeeded) {

--- a/backend/src/main/java/com/joying/ssafy/service/SsafyFinanceAdapter.java
+++ b/backend/src/main/java/com/joying/ssafy/service/SsafyFinanceAdapter.java
@@ -1,0 +1,54 @@
+package com.joying.ssafy.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.joying.common.config.ssafy.FinanceApiProperties;
+import com.joying.ssafy.dto.TransferOutcome;
+import com.joying.wallet.port.MoneyTransferPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 돈을 외부 금융망으로 옮기는 구현.
+ *
+ * <p>기본으로 켜지지 않는다. 이 프로젝트가 쓰던 SSAFY 금융망 교육용 API는 더 이상
+ * 붙을 수 없어, 지금 돈을 옮기는 자리는 내부 원장 구현이 맡는다.
+ * {@code joying.money.transfer=ssafy}로 두면 이쪽이 다시 붙는다.
+ *
+ * <p>코드를 지우지 않고 남긴 이유는, 밖으로 나가는 호출이 있을 때만 생기는 문제들
+ * 이 여기에 담겨 있기 때문이다. 타임아웃, 응답을 못 받았을 때의 미확정, 미확정을
+ * 다시 물어 확정하는 복구가 그것이다. 내부 원장으로 옮기면서 그 문제들이 사라진
+ * 것이 아니라, 경계를 안으로 들여서 겪지 않게 된 것이다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "joying.money.transfer", havingValue = "ssafy")
+public class SsafyFinanceAdapter implements MoneyTransferPort {
+
+	private final FinanceApiService financeApiService;
+	private final FinanceApiProperties financeApiProperties;
+
+	@Override
+	public TransferOutcome creditToEscrow(long amount, String reference, String description) {
+		return financeApiService.depositMoney(
+			financeApiProperties.getEscrow().getAccountNo(),
+			amount,
+			description,
+			financeApiProperties.getEscrow().getUserKey());
+	}
+
+	@Override
+	public TransferOutcome transferFromEscrow(Long toMemberId, long amount,
+											  String reference, String description) {
+		throw new UnsupportedOperationException(
+			"회원 계좌번호를 받아야 송금할 수 있다. 계좌 등록 경로가 살아난 뒤에 잇는다.");
+	}
+
+	@Override
+	public String name() {
+		return "ssafy";
+	}
+}

--- a/backend/src/main/java/com/joying/wallet/domain/EntryDirection.java
+++ b/backend/src/main/java/com/joying/wallet/domain/EntryDirection.java
@@ -1,0 +1,13 @@
+package com.joying.wallet.domain;
+
+/**
+ * 원장 한 줄의 방향.
+ */
+public enum EntryDirection {
+
+	/** 지갑에서 빠졌다 */
+	DEBIT,
+
+	/** 지갑에 들어왔다 */
+	CREDIT
+}

--- a/backend/src/main/java/com/joying/wallet/domain/Wallet.java
+++ b/backend/src/main/java/com/joying/wallet/domain/Wallet.java
@@ -1,0 +1,68 @@
+package com.joying.wallet.domain;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 잔액을 들고 있는 자리.
+ *
+ * <p>잔액은 이 엔티티를 읽고 고쳐 저장하는 방식으로 바꾸지 않는다. 동시에 두 이체가
+ * 들어오면 나중에 저장한 쪽이 앞엣것을 덮어 잔액이 맞지 않게 된다. 대신
+ * {@code WalletRepository}의 조건부 UPDATE로 DB에서 직접 더하고 뺀다.
+ * 잔액이 모자라면 그 UPDATE가 0행을 고쳐 실패가 드러난다.
+ */
+@Entity
+@Getter
+@Table(
+	name = "wallet",
+	uniqueConstraints = @UniqueConstraint(name = "uk_wallet_owner", columnNames = {"owner_type", "member_id"})
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Wallet {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "wallet_id")
+	private Long walletId;
+
+	@Comment("지갑 주인 구분")
+	@Enumerated(EnumType.STRING)
+	@Column(name = "owner_type", nullable = false, length = 16)
+	private WalletOwnerType ownerType;
+
+	@Comment("회원 지갑일 때의 회원 ID. 에스크로 지갑은 비어 있다")
+	@Column(name = "member_id")
+	private Long memberId;
+
+	@Comment("현재 잔액. 원 단위이며 음수가 될 수 없다")
+	@Column(name = "balance", nullable = false)
+	private Long balance;
+
+	public static Wallet forMember(Long memberId) {
+		Wallet wallet = new Wallet();
+		wallet.ownerType = WalletOwnerType.MEMBER;
+		wallet.memberId = memberId;
+		wallet.balance = 0L;
+		return wallet;
+	}
+
+	public static Wallet forEscrow() {
+		Wallet wallet = new Wallet();
+		wallet.ownerType = WalletOwnerType.ESCROW;
+		wallet.memberId = null;
+		wallet.balance = 0L;
+		return wallet;
+	}
+}

--- a/backend/src/main/java/com/joying/wallet/domain/WalletEntry.java
+++ b/backend/src/main/java/com/joying/wallet/domain/WalletEntry.java
@@ -1,0 +1,80 @@
+package com.joying.wallet.domain;
+
+import java.time.Instant;
+
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 원장 한 줄.
+ *
+ * <p>이체 한 건은 원장 두 줄을 남긴다. 나간 지갑에 한 줄, 들어온 지갑에 한 줄이다.
+ * 잔액은 지갑 행에도 들고 있지만 그것은 지금 값일 뿐이고, 어쩌다 그 값이 됐는지는
+ * 이 원장에만 남는다. 둘이 어긋나면 원장이 맞다.
+ *
+ * <p>{@code balanceAfter}는 그 줄이 적힌 직후의 잔액이다. 나중에 잔액이 이상할 때
+ * 어느 줄부터 어긋났는지 짚을 수 있게 같이 적는다.
+ */
+@Entity
+@Getter
+@Table(
+	name = "wallet_entry",
+	indexes = @Index(name = "idx_wallet_entry_wallet", columnList = "wallet_id, entry_id")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WalletEntry {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "entry_id")
+	private Long entryId;
+
+	@Comment("어느 지갑의 줄인가")
+	@Column(name = "wallet_id", nullable = false)
+	private Long walletId;
+
+	@Comment("어느 이체에서 나온 줄인가")
+	@Column(name = "transfer_id", nullable = false)
+	private Long transferId;
+
+	@Comment("들어왔는지 빠졌는지")
+	@Enumerated(EnumType.STRING)
+	@Column(name = "direction", nullable = false, length = 8)
+	private EntryDirection direction;
+
+	@Comment("금액. 언제나 양수이며 방향은 direction이 정한다")
+	@Column(name = "amount", nullable = false)
+	private Long amount;
+
+	@Comment("이 줄이 적힌 직후의 잔액")
+	@Column(name = "balance_after", nullable = false)
+	private Long balanceAfter;
+
+	@CreationTimestamp
+	@Column(name = "created_at", updatable = false)
+	private Instant createdAt;
+
+	public static WalletEntry of(Long walletId, Long transferId, EntryDirection direction,
+								 long amount, long balanceAfter) {
+		WalletEntry entry = new WalletEntry();
+		entry.walletId = walletId;
+		entry.transferId = transferId;
+		entry.direction = direction;
+		entry.amount = amount;
+		entry.balanceAfter = balanceAfter;
+		return entry;
+	}
+}

--- a/backend/src/main/java/com/joying/wallet/domain/WalletOwnerType.java
+++ b/backend/src/main/java/com/joying/wallet/domain/WalletOwnerType.java
@@ -1,0 +1,13 @@
+package com.joying.wallet.domain;
+
+/**
+ * 지갑 주인.
+ */
+public enum WalletOwnerType {
+
+	/** 회원 개인 지갑 */
+	MEMBER,
+
+	/** 거래 중인 돈을 중개가 들고 있는 지갑. 하나만 있다 */
+	ESCROW
+}

--- a/backend/src/main/java/com/joying/wallet/domain/WalletTransfer.java
+++ b/backend/src/main/java/com/joying/wallet/domain/WalletTransfer.java
@@ -1,0 +1,78 @@
+package com.joying.wallet.domain;
+
+import java.time.Instant;
+
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 돈이 한 번 움직인 기록.
+ *
+ * <p>{@code reference}에 유니크 제약이 걸려 있다. 같은 참조로 이체를 두 번 부르면
+ * 두 번째 삽입이 DB에서 막히고, 부르는 쪽은 그것을 보고 이미 처리된 건임을 안다.
+ * 멱등을 애플리케이션 조회로 확인하면 두 요청이 동시에 들어왔을 때 둘 다 없다고
+ * 읽고 둘 다 넣는다. 그래서 판정을 DB 제약에 맡겼다.
+ *
+ * <p>지갑이 비어 있는 쪽은 시스템 밖을 뜻한다. 보내는 지갑이 없으면 밖에서 들어온
+ * 것이고, 받는 지갑이 없으면 밖으로 나간 것이다.
+ */
+@Entity
+@Getter
+@Table(
+	name = "wallet_transfer",
+	uniqueConstraints = @UniqueConstraint(name = "uk_wallet_transfer_reference", columnNames = "reference")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WalletTransfer {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "transfer_id")
+	private Long transferId;
+
+	@Comment("이 이체를 가리키는 값. 두 번 생기지 않아야 한다")
+	@Column(name = "reference", nullable = false, length = 128)
+	private String reference;
+
+	@Comment("보내는 지갑. 비어 있으면 시스템 밖에서 들어온 것이다")
+	@Column(name = "from_wallet_id")
+	private Long fromWalletId;
+
+	@Comment("받는 지갑. 비어 있으면 시스템 밖으로 나간 것이다")
+	@Column(name = "to_wallet_id")
+	private Long toWalletId;
+
+	@Comment("옮긴 금액")
+	@Column(name = "amount", nullable = false)
+	private Long amount;
+
+	@Comment("무엇 때문에 옮겼는지")
+	@Column(name = "description", length = 255)
+	private String description;
+
+	@CreationTimestamp
+	@Column(name = "created_at", updatable = false)
+	private Instant createdAt;
+
+	public static WalletTransfer of(Long fromWalletId, Long toWalletId, long amount,
+									String reference, String description) {
+		WalletTransfer transfer = new WalletTransfer();
+		transfer.fromWalletId = fromWalletId;
+		transfer.toWalletId = toWalletId;
+		transfer.amount = amount;
+		transfer.reference = reference;
+		transfer.description = description;
+		return transfer;
+	}
+}

--- a/backend/src/main/java/com/joying/wallet/port/MoneyTransferPort.java
+++ b/backend/src/main/java/com/joying/wallet/port/MoneyTransferPort.java
@@ -1,0 +1,39 @@
+package com.joying.wallet.port;
+
+import com.joying.ssafy.dto.TransferOutcome;
+
+/**
+ * 돈을 옮기는 경계.
+ *
+ * <p>결제, 정산, 환불은 돈이 어디를 거쳐 옮겨지는지 몰라도 된다. 확정됐는지,
+ * 거절됐는지, 알 수 없는지만 알면 된다. 그래서 그 셋을 돌려주는 이 포트에만 의존한다.
+ *
+ * <p>구현이 둘이다. 하나는 외부 금융망을 부르고 하나는 내부 원장에 적는다. 외부를
+ * 부르는 쪽은 응답을 못 받는 일이 있어 미확정이 생기지만, 내부 원장은 커밋되거나
+ * 롤백되거나 둘뿐이라 미확정이 생기지 않는다. 미확정이라는 상태는 외부 경계가
+ * 만든 것이지 이 도메인이 원래 갖고 있던 것이 아니다.
+ *
+ * <p>모든 메서드는 {@code reference}를 받는다. 같은 참조로 두 번 부르면 돈은 한 번만
+ * 움직인다. 재시도와 복구가 이 약속 위에서 돈다.
+ */
+public interface MoneyTransferPort {
+
+	/**
+	 * 밖에서 들어온 돈을 에스크로가 들고 있는 자리에 적는다.
+	 *
+	 * @param reference 이 적립을 가리키는 값. 주문번호처럼 두 번 생기지 않는 것
+	 */
+	TransferOutcome creditToEscrow(long amount, String reference, String description);
+
+	/**
+	 * 에스크로가 들고 있던 돈을 회원에게 옮긴다.
+	 *
+	 * @param reference 이 이체를 가리키는 값
+	 */
+	TransferOutcome transferFromEscrow(Long toMemberId, long amount, String reference, String description);
+
+	/**
+	 * 이 구현이 무엇으로 돈을 옮기는지. 로그와 운영 화면에서 구분하는 데 쓴다.
+	 */
+	String name();
+}

--- a/backend/src/main/java/com/joying/wallet/repository/WalletEntryRepository.java
+++ b/backend/src/main/java/com/joying/wallet/repository/WalletEntryRepository.java
@@ -1,0 +1,14 @@
+package com.joying.wallet.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.joying.wallet.domain.WalletEntry;
+
+public interface WalletEntryRepository extends JpaRepository<WalletEntry, Long> {
+
+	List<WalletEntry> findByWalletIdOrderByEntryIdAsc(Long walletId);
+
+	List<WalletEntry> findByTransferId(Long transferId);
+}

--- a/backend/src/main/java/com/joying/wallet/repository/WalletRepository.java
+++ b/backend/src/main/java/com/joying/wallet/repository/WalletRepository.java
@@ -1,0 +1,41 @@
+package com.joying.wallet.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.joying.wallet.domain.Wallet;
+import com.joying.wallet.domain.WalletOwnerType;
+
+public interface WalletRepository extends JpaRepository<Wallet, Long> {
+
+	Optional<Wallet> findByOwnerTypeAndMemberId(WalletOwnerType ownerType, Long memberId);
+
+	Optional<Wallet> findFirstByOwnerType(WalletOwnerType ownerType);
+
+	/**
+	 * 잔액이 충분할 때만 뺀다.
+	 *
+	 * <p>엔티티를 읽어서 빼고 저장하면, 동시에 들어온 두 이체가 같은 잔액을 읽고
+	 * 각자 빼서 저장해 한쪽이 사라진다. 잔액이 음수로 내려가는 것도 그렇게 생긴다.
+	 * 조건을 WHERE에 넣어 DB가 한 번에 판정하게 하면 그 경합이 없다.
+	 *
+	 * @return 고친 행 수. 0이면 잔액이 모자라 빼지 않은 것이다
+	 */
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("update Wallet w set w.balance = w.balance - :amount "
+		+ "where w.walletId = :walletId and w.balance >= :amount")
+	int withdrawIfEnough(@Param("walletId") Long walletId, @Param("amount") long amount);
+
+	/**
+	 * 넣는다. 넣는 쪽은 막을 조건이 없다.
+	 *
+	 * @return 고친 행 수. 0이면 그런 지갑이 없는 것이다
+	 */
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("update Wallet w set w.balance = w.balance + :amount where w.walletId = :walletId")
+	int deposit(@Param("walletId") Long walletId, @Param("amount") long amount);
+}

--- a/backend/src/main/java/com/joying/wallet/repository/WalletTransferRepository.java
+++ b/backend/src/main/java/com/joying/wallet/repository/WalletTransferRepository.java
@@ -1,0 +1,12 @@
+package com.joying.wallet.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.joying.wallet.domain.WalletTransfer;
+
+public interface WalletTransferRepository extends JpaRepository<WalletTransfer, Long> {
+
+	Optional<WalletTransfer> findByReference(String reference);
+}

--- a/backend/src/main/java/com/joying/wallet/service/WalletService.java
+++ b/backend/src/main/java/com/joying/wallet/service/WalletService.java
@@ -1,0 +1,151 @@
+package com.joying.wallet.service;
+
+import java.util.Optional;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joying.ssafy.dto.TransferOutcome;
+import com.joying.wallet.domain.EntryDirection;
+import com.joying.wallet.domain.Wallet;
+import com.joying.wallet.domain.WalletEntry;
+import com.joying.wallet.domain.WalletOwnerType;
+import com.joying.wallet.domain.WalletTransfer;
+import com.joying.wallet.repository.WalletEntryRepository;
+import com.joying.wallet.repository.WalletRepository;
+import com.joying.wallet.repository.WalletTransferRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 지갑 사이에서 돈을 옮긴다.
+ *
+ * <p>옮기는 일은 한 트랜잭션 안에서 끝난다. 커밋되면 옮겨진 것이고 롤백되면 옮겨지지
+ * 않은 것이라, 옮겨졌는지 모르는 상태가 생기지 않는다. 그래서 이 서비스는
+ * {@link TransferOutcome.Unconfirmed}를 돌려주지 않는다.
+ *
+ * <p>순서가 중요하다. 이체 기록을 먼저 넣어 같은 참조가 두 번 들어오는 것을 DB
+ * 제약으로 막고, 그다음에 잔액을 뺀다. 잔액이 모자라면 방금 넣은 이체 기록을 지운다.
+ * 예외를 던져 롤백하지 않는 이유는, 이 메서드를 부르는 쪽이 같은 트랜잭션 안에 있어
+ * 롤백 표시가 그쪽 작업까지 되돌리기 때문이다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WalletService {
+
+	private final WalletRepository walletRepository;
+	private final WalletTransferRepository transferRepository;
+	private final WalletEntryRepository entryRepository;
+
+	/**
+	 * 회원 지갑을 가져온다. 없으면 만든다.
+	 */
+	@Transactional
+	public Wallet getOrCreateMemberWallet(Long memberId) {
+		return walletRepository.findByOwnerTypeAndMemberId(WalletOwnerType.MEMBER, memberId)
+			.orElseGet(() -> createWallet(Wallet.forMember(memberId),
+				() -> walletRepository.findByOwnerTypeAndMemberId(WalletOwnerType.MEMBER, memberId)));
+	}
+
+	/**
+	 * 중개가 거래 중인 돈을 들고 있는 지갑. 하나만 있다.
+	 */
+	@Transactional
+	public Wallet getOrCreateEscrowWallet() {
+		return walletRepository.findFirstByOwnerType(WalletOwnerType.ESCROW)
+			.orElseGet(() -> createWallet(Wallet.forEscrow(),
+				() -> walletRepository.findFirstByOwnerType(WalletOwnerType.ESCROW)));
+	}
+
+	private Wallet createWallet(Wallet wallet, java.util.function.Supplier<Optional<Wallet>> reload) {
+		try {
+			return walletRepository.saveAndFlush(wallet);
+		} catch (DataIntegrityViolationException e) {
+			// 같은 지갑을 동시에 만들려 한 것이다. 유니크 제약이 한쪽만 통과시켰다.
+			return reload.get().orElseThrow(() -> e);
+		}
+	}
+
+	/**
+	 * 돈을 옮긴다.
+	 *
+	 * @param fromWalletId 보내는 지갑. null이면 시스템 밖에서 들어온 것
+	 * @param toWalletId   받는 지갑. null이면 시스템 밖으로 나가는 것
+	 * @param reference    이 이체를 가리키는 값. 같은 값으로 두 번 불러도 한 번만 옮긴다
+	 */
+	@Transactional
+	public TransferOutcome transfer(Long fromWalletId, Long toWalletId, long amount,
+									String reference, String description) {
+		if (amount <= 0) {
+			return new TransferOutcome.Rejected("INVALID_AMOUNT", "옮길 금액이 0 이하다: " + amount);
+		}
+		if (fromWalletId == null && toWalletId == null) {
+			return new TransferOutcome.Rejected("NO_WALLET", "보내는 곳과 받는 곳이 모두 비어 있다");
+		}
+
+		Optional<WalletTransfer> already = transferRepository.findByReference(reference);
+		if (already.isPresent()) {
+			log.info("[지갑] 이미 처리된 이체다: reference={}, transferId={}",
+				reference, already.get().getTransferId());
+			return new TransferOutcome.Succeeded(String.valueOf(already.get().getTransferId()));
+		}
+
+		WalletTransfer transfer;
+		try {
+			transfer = transferRepository.saveAndFlush(
+				WalletTransfer.of(fromWalletId, toWalletId, amount, reference, description));
+		} catch (DataIntegrityViolationException e) {
+			// 같은 참조가 동시에 들어왔고 다른 쪽이 먼저 넣었다. 돈은 그쪽이 옮긴다.
+			return transferRepository.findByReference(reference)
+				.map(t -> (TransferOutcome) new TransferOutcome.Succeeded(String.valueOf(t.getTransferId())))
+				.orElseGet(() -> new TransferOutcome.Rejected("DUPLICATE_REFERENCE", reference));
+		}
+
+		if (fromWalletId != null) {
+			int withdrawn = walletRepository.withdrawIfEnough(fromWalletId, amount);
+			if (withdrawn == 0) {
+				// 잔액이 모자라거나 그런 지갑이 없다. 방금 넣은 이체 기록을 되돌린다.
+				transferRepository.delete(transfer);
+				transferRepository.flush();
+				log.warn("[지갑] 잔액 부족으로 이체하지 않았다: walletId={}, amount={}, reference={}",
+					fromWalletId, amount, reference);
+				return new TransferOutcome.Rejected("INSUFFICIENT_BALANCE",
+					"잔액이 모자라거나 지갑이 없다: walletId=" + fromWalletId);
+			}
+			writeEntry(fromWalletId, transfer.getTransferId(), EntryDirection.DEBIT, amount);
+		}
+
+		if (toWalletId != null) {
+			int deposited = walletRepository.deposit(toWalletId, amount);
+			if (deposited == 0) {
+				// 받는 지갑이 없다. 여기서 멈추면 보낸 쪽만 줄어드므로 예외를 던져 되돌린다.
+				throw new IllegalStateException("받는 지갑이 없다: walletId=" + toWalletId);
+			}
+			writeEntry(toWalletId, transfer.getTransferId(), EntryDirection.CREDIT, amount);
+		}
+
+		log.info("[지갑] 이체 완료: {} → {}, amount={}, reference={}",
+			fromWalletId, toWalletId, amount, reference);
+		return new TransferOutcome.Succeeded(String.valueOf(transfer.getTransferId()));
+	}
+
+	private void writeEntry(Long walletId, Long transferId, EntryDirection direction, long amount) {
+		long balanceAfter = walletRepository.findById(walletId)
+			.map(Wallet::getBalance)
+			.orElseThrow(() -> new IllegalStateException("지갑이 사라졌다: walletId=" + walletId));
+		entryRepository.save(WalletEntry.of(walletId, transferId, direction, amount, balanceAfter));
+	}
+
+	/**
+	 * 원장을 더해 나온 잔액. 지갑 행의 잔액과 어긋나면 원장이 맞다.
+	 */
+	@Transactional(readOnly = true)
+	public long balanceFromLedger(Long walletId) {
+		return entryRepository.findByWalletIdOrderByEntryIdAsc(walletId).stream()
+			.mapToLong(e -> e.getDirection() == EntryDirection.CREDIT ? e.getAmount() : -e.getAmount())
+			.sum();
+	}
+}

--- a/backend/src/main/java/com/joying/wallet/service/WalletTransferAdapter.java
+++ b/backend/src/main/java/com/joying/wallet/service/WalletTransferAdapter.java
@@ -1,0 +1,54 @@
+package com.joying.wallet.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joying.ssafy.dto.TransferOutcome;
+import com.joying.wallet.port.MoneyTransferPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 돈을 내부 원장에서 옮기는 구현. 기본값이다.
+ *
+ * <p>외부 금융망을 쓰던 자리를 대신한다. 밖으로 나가는 호출이 없으므로 응답을 못 받는
+ * 일이 없고, 따라서 {@link TransferOutcome.Unconfirmed}를 돌려주지 않는다. 미확정을
+ * 다루는 장치를 걷어내지 않고 그대로 둔 이유는, 그 상태가 필요 없어진 것이 아니라
+ * 이 구현에서만 생기지 않기 때문이다. 외부 금융망 구현으로 되돌리면 다시 생긴다.
+ *
+ * <p>실제 계좌로 빼는 출금은 만들지 않았다. 그것만은 밖으로 나가는 호출이 필요하다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "joying.money.transfer", havingValue = "wallet", matchIfMissing = true)
+public class WalletTransferAdapter implements MoneyTransferPort {
+
+	private final WalletService walletService;
+
+	@Override
+	@Transactional
+	public TransferOutcome creditToEscrow(long amount, String reference, String description) {
+		Long escrowWalletId = walletService.getOrCreateEscrowWallet().getWalletId();
+		return walletService.transfer(null, escrowWalletId, amount, reference, description);
+	}
+
+	@Override
+	@Transactional
+	public TransferOutcome transferFromEscrow(Long toMemberId, long amount,
+											  String reference, String description) {
+		if (toMemberId == null) {
+			return new TransferOutcome.Rejected("NO_MEMBER", "받을 회원이 없다");
+		}
+		Long escrowWalletId = walletService.getOrCreateEscrowWallet().getWalletId();
+		Long memberWalletId = walletService.getOrCreateMemberWallet(toMemberId).getWalletId();
+		return walletService.transfer(escrowWalletId, memberWalletId, amount, reference, description);
+	}
+
+	@Override
+	public String name() {
+		return "wallet";
+	}
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -127,6 +127,13 @@ cloudflare.r2.secret-key=${CLOUDFLARE_R2_SECRET_KEY}
 app.file.public-base-url=${CLOUDFLARE_R2_PUBLIC_BASE_URL}
 
 # -------------------------------------
+# 돈을 무엇으로 옮기는가
+# -------------------------------------
+# wallet: 내부 원장. 기본값
+# ssafy : 외부 금융망. 교육용 API에 더 이상 붙을 수 없어 꺼 두었다
+joying.money.transfer=${JOYING_MONEY_TRANSFER:wallet}
+
+# -------------------------------------
 # SSAFY 금융망 API
 # -------------------------------------
 ssafy.finance.base-url=${SSAFY_FINANCE_BASE_URL:https://finopenapi.ssafy.io}

--- a/backend/src/test/java/com/joying/wallet/WalletTransferTest.java
+++ b/backend/src/test/java/com/joying/wallet/WalletTransferTest.java
@@ -1,0 +1,218 @@
+package com.joying.wallet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MySQLContainer;
+
+import com.joying.ssafy.dto.TransferOutcome;
+import com.joying.wallet.domain.Wallet;
+import com.joying.wallet.repository.WalletEntryRepository;
+import com.joying.wallet.repository.WalletRepository;
+import com.joying.wallet.repository.WalletTransferRepository;
+import com.joying.wallet.service.WalletService;
+
+/**
+ * 지갑 사이 이체.
+ *
+ * <p>돈이 걸린 자리라 인메모리 DB로 재지 않는다. 잔액을 조건부 UPDATE로 빼는 것과
+ * 참조에 걸린 유니크 제약이 실제로 경합을 막아 주는지는 쓰는 DB에 달려 있다.
+ */
+@DataJpaTest
+@Import(WalletService.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class WalletTransferTest {
+
+	@SuppressWarnings("resource")
+	static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+		.withDatabaseName("joying_test");
+
+	static {
+		MYSQL.start();
+	}
+
+	@DynamicPropertySource
+	static void datasource(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+		registry.add("spring.datasource.username", MYSQL::getUsername);
+		registry.add("spring.datasource.password", MYSQL::getPassword);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+	}
+
+	@Autowired
+	WalletService walletService;
+
+	@Autowired
+	WalletRepository walletRepository;
+
+	@Autowired
+	WalletTransferRepository transferRepository;
+
+	@Autowired
+	WalletEntryRepository entryRepository;
+
+	private Long escrowWalletId;
+	private Long memberWalletId;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트마다 잔액을 0에서 시작한다. 트랜잭션 롤백에 기대지 않는 이유는
+		// 동시성 테스트가 진짜 스레드와 진짜 커밋으로 돌아야 하기 때문이다.
+		entryRepository.deleteAllInBatch();
+		transferRepository.deleteAllInBatch();
+		walletRepository.deleteAllInBatch();
+
+		escrowWalletId = walletService.getOrCreateEscrowWallet().getWalletId();
+		memberWalletId = walletService.getOrCreateMemberWallet(1L).getWalletId();
+	}
+
+	private long balanceOf(Long walletId) {
+		return walletRepository.findById(walletId).orElseThrow().getBalance();
+	}
+
+	@Test
+	@DisplayName("밖에서 들어온 돈이 에스크로 지갑에 적립된다")
+	void creditFromOutside() {
+		long before = balanceOf(escrowWalletId);
+
+		TransferOutcome outcome = walletService.transfer(
+			null, escrowWalletId, 10_000L, "ref-credit-1", "결제 적립");
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Succeeded.class);
+		assertThat(balanceOf(escrowWalletId)).isEqualTo(before + 10_000L);
+	}
+
+	@Test
+	@DisplayName("같은 참조로 두 번 불러도 돈은 한 번만 움직인다")
+	void sameReferenceMovesMoneyOnce() {
+		long before = balanceOf(escrowWalletId);
+
+		TransferOutcome first = walletService.transfer(
+			null, escrowWalletId, 7_000L, "ref-once", "결제 적립");
+		TransferOutcome second = walletService.transfer(
+			null, escrowWalletId, 7_000L, "ref-once", "결제 적립");
+
+		assertThat(first).isInstanceOf(TransferOutcome.Succeeded.class);
+		assertThat(second).isInstanceOf(TransferOutcome.Succeeded.class);
+		assertThat(second.transactionUniqueNoOrNull())
+			.as("두 번째는 첫 번째 이체를 그대로 가리킨다")
+			.isEqualTo(first.transactionUniqueNoOrNull());
+		assertThat(balanceOf(escrowWalletId)).isEqualTo(before + 7_000L);
+	}
+
+	@Test
+	@DisplayName("잔액보다 큰 이체는 거절되고 잔액이 그대로다")
+	void rejectsWhenBalanceIsNotEnough() {
+		walletService.transfer(null, escrowWalletId, 5_000L, "ref-seed-1", "적립");
+		long before = balanceOf(escrowWalletId);
+
+		TransferOutcome outcome = walletService.transfer(
+			escrowWalletId, memberWalletId, before + 1L, "ref-too-much", "정산");
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Rejected.class);
+		assertThat(((TransferOutcome.Rejected) outcome).responseCode())
+			.isEqualTo("INSUFFICIENT_BALANCE");
+		assertThat(balanceOf(escrowWalletId)).isEqualTo(before);
+		assertThat(balanceOf(memberWalletId)).isZero();
+	}
+
+	@Test
+	@DisplayName("거절된 이체는 기록도 남기지 않아 같은 참조로 다시 시도할 수 있다")
+	void rejectedTransferCanBeRetriedWithSameReference() {
+		TransferOutcome rejected = walletService.transfer(
+			escrowWalletId, memberWalletId, 3_000L, "ref-retry", "정산");
+		assertThat(rejected).isInstanceOf(TransferOutcome.Rejected.class);
+
+		walletService.transfer(null, escrowWalletId, 3_000L, "ref-seed-2", "적립");
+
+		TransferOutcome retried = walletService.transfer(
+			escrowWalletId, memberWalletId, 3_000L, "ref-retry", "정산");
+
+		assertThat(retried).isInstanceOf(TransferOutcome.Succeeded.class);
+		assertThat(balanceOf(memberWalletId)).isEqualTo(3_000L);
+	}
+
+	@Test
+	@DisplayName("잔액 20,000원에 5,000원 이체 10건이 동시에 들어와도 4건만 나가고 잔액은 음수가 되지 않는다")
+	void concurrentTransfersNeverGoBelowZero() throws Exception {
+		walletService.transfer(null, escrowWalletId, 20_000L, "ref-seed-3", "적립");
+
+		int attempts = 10;
+		long amount = 5_000L;
+		ExecutorService pool = Executors.newFixedThreadPool(attempts);
+		List<Callable<TransferOutcome>> tasks = IntStream.range(0, attempts)
+			.<Callable<TransferOutcome>>mapToObj(i -> () -> walletService.transfer(
+				escrowWalletId, memberWalletId, amount, "ref-concurrent-" + i, "정산"))
+			.toList();
+
+		List<Future<TransferOutcome>> futures = pool.invokeAll(tasks);
+		pool.shutdown();
+		pool.awaitTermination(30, TimeUnit.SECONDS);
+
+		long succeeded = 0;
+		for (Future<TransferOutcome> f : futures) {
+			if (f.get() instanceof TransferOutcome.Succeeded) {
+				succeeded++;
+			}
+		}
+
+		assertThat(succeeded).as("20,000원으로는 5,000원 이체를 넷까지만 할 수 있다").isEqualTo(4);
+		assertThat(balanceOf(escrowWalletId)).isZero();
+		assertThat(balanceOf(memberWalletId)).isEqualTo(20_000L);
+	}
+
+	@Test
+	@DisplayName("같은 참조로 동시에 들어와도 한 번만 나간다")
+	void concurrentSameReferenceMovesMoneyOnce() throws Exception {
+		walletService.transfer(null, escrowWalletId, 20_000L, "ref-seed-4", "적립");
+
+		int attempts = 8;
+		ExecutorService pool = Executors.newFixedThreadPool(attempts);
+		List<Callable<TransferOutcome>> tasks = IntStream.range(0, attempts)
+			.<Callable<TransferOutcome>>mapToObj(i -> () -> walletService.transfer(
+				escrowWalletId, memberWalletId, 5_000L, "ref-same", "정산"))
+			.toList();
+
+		pool.invokeAll(tasks);
+		pool.shutdown();
+		pool.awaitTermination(30, TimeUnit.SECONDS);
+
+		assertThat(balanceOf(memberWalletId))
+			.as("같은 참조라 돈은 한 번만 움직인다")
+			.isEqualTo(5_000L);
+		assertThat(balanceOf(escrowWalletId)).isEqualTo(15_000L);
+	}
+
+	@Test
+	@DisplayName("원장을 더한 값이 지갑 잔액과 같다")
+	void ledgerAgreesWithBalance() {
+		walletService.transfer(null, escrowWalletId, 30_000L, "ref-led-1", "적립");
+		walletService.transfer(escrowWalletId, memberWalletId, 12_000L, "ref-led-2", "정산");
+		walletService.transfer(escrowWalletId, memberWalletId, 3_000L, "ref-led-3", "정산");
+
+		assertThat(walletService.balanceFromLedger(escrowWalletId))
+			.isEqualTo(balanceOf(escrowWalletId));
+		assertThat(walletService.balanceFromLedger(memberWalletId))
+			.isEqualTo(balanceOf(memberWalletId));
+		assertThat(balanceOf(memberWalletId)).isEqualTo(15_000L);
+	}
+}


### PR DESCRIPTION
Closes #7
Base: #15 (feat/deposit-recovery)

`MoneyTransferPort`를 뽑고 내부 원장 구현을 기본으로 뒀다. 금융망 구현은 지우지 않고 설정으로만 켜지게 남겼다.

잔액은 조건부 UPDATE로만 바꾸고, 멱등은 참조 유니크 제약으로 판정한다. 실 MySQL 컨테이너에서 동시성까지 쟀다.

지갑 이체는 커밋되거나 롤백되거나 둘뿐이라 미확정이 생기지 않는다. 미확정을 다루는 장치를 남긴 이유는 그 상태가 외부 경계가 만든 것이기 때문이다.