### PR TITLE
fix: 타이핑과 읽음, 접속 상태가 서버를 넘어 닿게 한다

### DIFF
--- a/backend/src/main/kotlin/com/joying/chat/broadcast/ChatBroadcast.kt
+++ b/backend/src/main/kotlin/com/joying/chat/broadcast/ChatBroadcast.kt
@@ -1,0 +1,38 @@
+package com.joying.chat.broadcast
+
+/**
+ * 서버를 넘어야 하는 전달 한 건.
+ *
+ * 로컬 브로커는 구독 정보를 자기 메모리에만 들고 있어서, 보낸 서버에 붙어 있지 않은
+ * 상대에게는 닿지 않는다. 그래서 밖으로 나가야 하는 것은 전부 이 봉투에 담아 Redis로
+ * 보내고, 각 서버가 받아서 자기에게 붙은 세션에만 내보낸다.
+ *
+ * 페이로드를 JSON 문자열로 들고 다니는 이유는, 봉투 하나로 여러 종류를 실어 나르면서
+ * 받는 쪽이 타입 정보를 따로 설정하지 않아도 되게 하기 위해서다. 받는 쪽은 이것을
+ * 해석하지 않고 그대로 브로커에 넘긴다.
+ */
+data class ChatBroadcast(
+    /** 특정 회원에게 보낼 것인지, 방을 구독한 모두에게 보낼 것인지 */
+    val kind: Kind,
+
+    /** [Kind.USER]일 때 받을 회원. 아니면 null */
+    val userId: Long? = null,
+
+    /** 브로커 목적지. 예: /queue/chatroom-update, /topic/chat/1/typing */
+    val destination: String,
+
+    /** 실어 나르는 내용. 받는 쪽은 해석하지 않는다 */
+    val payloadJson: String
+) {
+    enum class Kind {
+        /** 한 회원의 세션들에 보낸다 */
+        USER,
+
+        /** 목적지를 구독한 모두에게 보낸다 */
+        TOPIC
+    }
+
+    companion object {
+        const val CHANNEL = "chat:broadcast"
+    }
+}

--- a/backend/src/main/kotlin/com/joying/chat/broadcast/ChatBroadcastListener.kt
+++ b/backend/src/main/kotlin/com/joying/chat/broadcast/ChatBroadcastListener.kt
@@ -1,0 +1,57 @@
+package com.joying.chat.broadcast
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * 다른 서버가 보낸 것을 받아 자기에게 붙은 세션으로 내보낸다.
+ *
+ * 페이로드를 문자열 그대로 넘기지 않고 객체로 풀어서 넘긴다. 문자열로 넘기면
+ * 클라이언트가 JSON 안에 JSON이 든 것을 받아 한 번 더 풀어야 한다.
+ *
+ * 자기가 보낸 것도 다시 받는다. Redis Pub/Sub은 발행자에게도 되돌려 주기 때문이다.
+ * 그래서 보내는 쪽은 로컬 브로커를 직접 부르지 않는다. 부르면 자기 서버에 붙은
+ * 사람에게 두 번 간다.
+ */
+@Component
+class ChatBroadcastListener(
+    private val messagingTemplate: SimpMessagingTemplate,
+    private val objectMapper: ObjectMapper
+) : MessageListener {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        try {
+            val broadcast = objectMapper.readValue(message.body, ChatBroadcast::class.java)
+
+            when (broadcast.kind) {
+                ChatBroadcast.Kind.USER -> {
+                    val userId = broadcast.userId
+                    if (userId == null) {
+                        logger.warn("받을 회원이 없다: destination={}", broadcast.destination)
+                        return
+                    }
+                    messagingTemplate.convertAndSendToUser(
+                        userId.toString(),
+                        broadcast.destination,
+                        objectMapper.readTree(broadcast.payloadJson)
+                    )
+                }
+
+                ChatBroadcast.Kind.TOPIC ->
+                    messagingTemplate.convertAndSend(
+                        broadcast.destination,
+                        objectMapper.readTree(broadcast.payloadJson)
+                    )
+            }
+        } catch (e: Exception) {
+            // 한 건이 깨져도 나머지 전달은 계속 받아야 한다.
+            logger.warn("전달 처리 실패: error={}", e.message)
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/joying/chat/broadcast/ChatBroadcaster.kt
+++ b/backend/src/main/kotlin/com/joying/chat/broadcast/ChatBroadcaster.kt
@@ -1,0 +1,58 @@
+package com.joying.chat.broadcast
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * 서버를 넘어야 하는 전달을 내보내는 자리.
+ *
+ * 예전에는 각자 [org.springframework.messaging.simp.SimpMessagingTemplate]을 직접
+ * 불렀다. 그러면 보낸 서버 안에서만 돌고, 새 목적지가 생길 때마다 서버를 넘기는 것을
+ * 또 잊는다. 실제로 채팅 메시지 본문만 Redis를 타고 타이핑·읽음·접속 상태·안읽음
+ * 배지는 전부 빠져 있었다.
+ *
+ * 나가는 자리를 하나로 모아 두면, 새 목적지를 더하는 사람이 무엇을 해야 하는지
+ * 고르지 않아도 된다.
+ */
+@Component
+class ChatBroadcaster(
+    private val stringRedisTemplate: StringRedisTemplate,
+    private val objectMapper: ObjectMapper
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * 한 회원에게 보낸다. 그 회원이 어느 서버에 붙어 있든 닿는다.
+     */
+    fun toUser(userId: Long, destination: String, payload: Any) {
+        publish(ChatBroadcast(ChatBroadcast.Kind.USER, userId, destination, toJson(payload)))
+    }
+
+    /**
+     * 목적지를 구독한 모두에게 보낸다.
+     */
+    fun toTopic(destination: String, payload: Any) {
+        publish(ChatBroadcast(ChatBroadcast.Kind.TOPIC, null, destination, toJson(payload)))
+    }
+
+    private fun publish(broadcast: ChatBroadcast) {
+        try {
+            stringRedisTemplate.convertAndSend(
+                ChatBroadcast.CHANNEL,
+                objectMapper.writeValueAsString(broadcast)
+            )
+        } catch (e: Exception) {
+            // 전달에 실패해도 그것 때문에 부르는 쪽의 작업을 되돌리지 않는다.
+            // 방 목록이나 타이핑 표시가 한 번 빠지는 것과, 저장된 것을 되돌리는 것 중
+            // 뒤엣것이 훨씬 비싸다.
+            logger.warn(
+                "전달 발행 실패: kind={}, destination={}, error={}",
+                broadcast.kind, broadcast.destination, e.message
+            )
+        }
+    }
+
+    private fun toJson(payload: Any): String = objectMapper.writeValueAsString(payload)
+}

--- a/backend/src/main/kotlin/com/joying/chat/config/RedisPubSubConfig.kt
+++ b/backend/src/main/kotlin/com/joying/chat/config/RedisPubSubConfig.kt
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import com.joying.chat.broadcast.ChatBroadcast
+import com.joying.chat.broadcast.ChatBroadcastListener
 import org.springframework.data.redis.listener.ChannelTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
@@ -69,13 +71,18 @@ class RedisPubSubConfig {
     @Bean
     fun redisMessageListenerContainer(
         connectionFactory: RedisConnectionFactory,
-        chatMessageListener: ChatMessageListener
+        chatMessageListener: ChatMessageListener,
+        chatBroadcastListener: ChatBroadcastListener
     ): RedisMessageListenerContainer {
         val container = RedisMessageListenerContainer()
         container.setConnectionFactory(connectionFactory)
 
-        // chat:messages 채널 구독
+        // chat:messages 채널 구독 (메시지 본문)
         container.addMessageListener(chatMessageListener, ChannelTopic(CHAT_MESSAGE_CHANNEL))
+
+        // chat:broadcast 채널 구독
+        // 타이핑, 읽음, 접속 상태, 방 목록 갱신처럼 서버를 넘어야 하는 나머지가 여기로 온다.
+        container.addMessageListener(chatBroadcastListener, ChannelTopic(ChatBroadcast.CHANNEL))
 
         return container
     }

--- a/backend/src/main/kotlin/com/joying/chat/service/ChatPresenceService.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/ChatPresenceService.kt
@@ -1,5 +1,7 @@
 package com.joying.chat.service
 
+import com.joying.chat.broadcast.ChatBroadcaster
+
 import com.joying.chat.dto.PresenceUpdateEvent
 import com.joying.chat.repository.ChatRoomMemberRepository
 import org.springframework.data.redis.core.RedisTemplate
@@ -25,6 +27,7 @@ import java.util.concurrent.TimeUnit
 class ChatPresenceService(
     private val redisTemplate: RedisTemplate<String, String>,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val chatBroadcaster: ChatBroadcaster,
     private val chatRoomMemberRepository: ChatRoomMemberRepository
 ) {
 
@@ -194,11 +197,7 @@ class ChatPresenceService(
                     )
 
                     // 상대방에게 WebSocket으로 전송
-                    messagingTemplate.convertAndSendToUser(
-                        otherMemberId.toString(),
-                        "/queue/presence-update",
-                        event
-                    )
+                    chatBroadcaster.toUser(otherMemberId, "/queue/presence-update", event)
                 }
             }
         } catch (e: Exception) {

--- a/backend/src/main/kotlin/com/joying/chat/service/ChatRoomService.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/ChatRoomService.kt
@@ -1,5 +1,7 @@
 package com.joying.chat.service
 
+import com.joying.chat.broadcast.ChatBroadcaster
+
 import com.joying.chat.domain.ChatRoom
 import com.joying.chat.domain.ChatRoomMember
 import com.joying.chat.domain.ChatRoomStatus
@@ -47,6 +49,7 @@ class ChatRoomService(
     private val fileUrlResolver: FileUrlResolver,
     private val permissionCache: ChatRoomPermissionCache,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val chatBroadcaster: ChatBroadcaster,
     private val redisPubSubPublisher: RedisPubSubPublisher,
 ) {
     private val logger = LoggerFactory.getLogger(ChatRoomService::class.java)
@@ -525,11 +528,7 @@ class ChatRoomService(
                         memberNickname = leavingMember.getNickname(),
                     )
 
-                messagingTemplate.convertAndSendToUser(
-                    otherMemberId.toString(),
-                    "/queue/chatroom-status",
-                    event,
-                )
+                chatBroadcaster.toUser(otherMemberId, "/queue/chatroom-status", event)
 
                 logger.debug("채팅방 나가기 메시지 저장 및 이벤트 전송: chatRoomId={}, to={}", chatRoomId, otherMemberId)
             } catch (e: Exception) {
@@ -625,18 +624,10 @@ class ChatRoomService(
                         )
 
                     // 구매자에게 알림
-                    messagingTemplate.convertAndSendToUser(
-                        chatRoom.buyer.memberId.toString(),
-                        "/queue/chatroom-status",
-                        event,
-                    )
+                    chatBroadcaster.toUser(chatRoom.buyer.memberId, "/queue/chatroom-status", event)
 
                     // 판매자에게 알림
-                    messagingTemplate.convertAndSendToUser(
-                        chatRoom.seller.memberId.toString(),
-                        "/queue/chatroom-status",
-                        event,
-                    )
+                    chatBroadcaster.toUser(chatRoom.seller.memberId, "/queue/chatroom-status", event)
 
                     logger.debug(
                         "채팅방 자동 종료 메시지 저장 및 이벤트 전송: chatRoomId={}, to=[{}, {}]",
@@ -847,11 +838,7 @@ class ChatRoomService(
                         memberNickname = rejoiningMemberNickname,
                     )
 
-                messagingTemplate.convertAndSendToUser(
-                    receiverId.toString(),
-                    "/queue/chatroom-status",
-                    event,
-                )
+                chatBroadcaster.toUser(receiverId, "/queue/chatroom-status", event)
 
                 logger.info("채팅방 재입장 WebSocket 알림 전송 완료: chatRoomId={}, memberId={}, to={}", chatRoomId, memberId, receiverId)
             } catch (e: Exception) {

--- a/backend/src/main/kotlin/com/joying/chat/service/ChatService.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/ChatService.kt
@@ -1,5 +1,7 @@
 package com.joying.chat.service
 
+import com.joying.chat.broadcast.ChatBroadcaster
+
 import com.joying.chat.document.ChatMessage
 import com.joying.chat.document.MessageType
 import com.joying.chat.dto.ChatMessageResponse
@@ -46,6 +48,7 @@ class ChatService(
     private val webPushService: WebPushService,
     private val chatPresenceService: ChatPresenceService,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val chatBroadcaster: ChatBroadcaster,
     private val chatRoomService: ChatRoomService,
     private val mongoTemplate: MongoTemplate,
 ) {
@@ -221,11 +224,7 @@ class ChatService(
             unreadCount = unreadCount
         )
 
-        messagingTemplate.convertAndSendToUser(
-            receiverId.toString(),
-            "/queue/chatroom-update",
-            chatRoomUpdate
-        )
+        chatBroadcaster.toUser(receiverId, "/queue/chatroom-update", chatRoomUpdate)
 
         logger.debug(
             "채팅방 목록 업데이트 이벤트 전송: chatRoomId={}, receiverId={}, unreadCount={}",
@@ -439,11 +438,7 @@ class ChatService(
                     "tag" to payload.tag,
                     "data" to payload.data
                 )
-                messagingTemplate.convertAndSendToUser(
-                    receiverId.toString(),
-                    "/queue/notifications",
-                    notificationData
-                )
+                chatBroadcaster.toUser(receiverId, "/queue/notifications", notificationData)
                 logger.debug("WebSocket 알림 전송 완료 (1순위): receiverId={}", receiverId)
             } catch (e: Exception) {
                 logger.debug("WebSocket 알림 전송 실패 (정상 - 오프라인일 수 있음): receiverId={}", receiverId)
@@ -512,11 +507,7 @@ class ChatService(
                     memberNickname = rejoiningMemberNickname
                 )
 
-                messagingTemplate.convertAndSendToUser(
-                    receiverId.toString(),
-                    "/queue/chatroom-status",
-                    event
-                )
+                chatBroadcaster.toUser(receiverId, "/queue/chatroom-status", event)
 
                 logger.info("채팅방 재입장 WebSocket 알림 전송 완료: chatRoomId={}, memberId={}, to={}", chatRoomId, memberId, receiverId)
             } catch (e: Exception) {

--- a/backend/src/main/kotlin/com/joying/chat/websocket/ChatWebSocketHandler.kt
+++ b/backend/src/main/kotlin/com/joying/chat/websocket/ChatWebSocketHandler.kt
@@ -1,5 +1,7 @@
 package com.joying.chat.websocket
 
+import com.joying.chat.broadcast.ChatBroadcaster
+
 import com.joying.chat.dto.SendMessageRequest
 import com.joying.chat.service.ChatPresenceService
 import com.joying.chat.service.ChatService
@@ -23,6 +25,7 @@ import org.springframework.stereotype.Controller
 class ChatWebSocketHandler(
     private val chatService: ChatService,
     private val messagingTemplate: SimpMessagingTemplate,
+    private val chatBroadcaster: ChatBroadcaster,
     private val chatPresenceService: ChatPresenceService
 ) {
     private val logger = LoggerFactory.getLogger(ChatWebSocketHandler::class.java)
@@ -101,7 +104,7 @@ class ChatWebSocketHandler(
             "isTyping" to true
         )
 
-        messagingTemplate.convertAndSend("/topic/chat/$chatRoomId/typing", typingEvent)
+        chatBroadcaster.toTopic("/topic/chat/$chatRoomId/typing", typingEvent)
     }
 
     /**
@@ -132,7 +135,7 @@ class ChatWebSocketHandler(
             "readAt" to System.currentTimeMillis()
         )
 
-        messagingTemplate.convertAndSend("/topic/chat/$chatRoomId/read", readEvent)
+        chatBroadcaster.toTopic("/topic/chat/$chatRoomId/read", readEvent)
     }
 
     /**

--- a/backend/src/test/java/com/joying/JoyingApplicationTests.java
+++ b/backend/src/test/java/com/joying/JoyingApplicationTests.java
@@ -3,38 +3,39 @@ package com.joying;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Spring Boot 애플리케이션 컨텍스트 로딩 테스트
  *
- * Testcontainers를 사용하여 실제 Redis 컨테이너와 함께 테스트합니다.
- * TestcontainersConfiguration이 Redis 컨테이너를 자동으로 시작하고
- * @DynamicPropertySource가 컨테이너의 연결 정보를 Spring 환경에 주입합니다.
+ * TestcontainersConfiguration이 MySQL, MongoDB, Redis 컨테이너를 띄우고
+ * 접속 정보를 설정으로 넣어 준다. 컨텍스트가 실제로 뜨는지만 확인한다.
  */
 @SpringBootTest
+// local을 같이 켜는 이유는 TossPaymentsClientImpl이 @Profile({"prod","local"})이라
+// test만으로는 그 빈이 없어 결제 쪽 배선이 통째로 빠지기 때문이다. 붙는 주소는
+// 컨테이너가 덮어쓴다.
+@ActiveProfiles({"local", "test"})
 @Import(TestcontainersConfiguration.class)
 class JoyingApplicationTests {
 
 	/**
-	 * Redis 컨테이너의 연결 정보를 Spring 환경에 동적으로 주입
-	 *
-	 * TestcontainersConfiguration에서 시작된 Redis 컨테이너의
-	 * 호스트와 포트 정보를 가져와서 spring.data.redis 설정을 오버라이드합니다.
+	 * RedisConfig가 연결 팩토리를 설정값으로 직접 만들어 컨테이너 접속 정보를 보지 않는다.
+	 * 그래서 이 자리만 손으로 넣어 준다.
 	 */
 	@DynamicPropertySource
 	static void redisProperties(DynamicPropertyRegistry registry) {
 		registry.add("spring.data.redis.host",
 			() -> TestcontainersConfiguration.getRedisContainer().getHost());
 		registry.add("spring.data.redis.port",
-			() -> TestcontainersConfiguration.getRedisContainer().getMappedPort(6379).toString());
+			() -> TestcontainersConfiguration.getRedisContainer().getMappedPort(6379));
 	}
 
 	@Test
 	void contextLoads() {
-		// Spring Boot 컨텍스트가 정상적으로 로딩되는지 확인
-		// Redis 컨테이너가 자동으로 시작되어 연결됨
+		// 컨텍스트가 뜨면 통과다. 빈 하나가 잘못 묶여 있어도 여기서 걸린다.
 	}
 
 }

--- a/backend/src/test/java/com/joying/TestcontainersConfiguration.java
+++ b/backend/src/test/java/com/joying/TestcontainersConfiguration.java
@@ -1,27 +1,49 @@
 package com.joying;
 
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * 테스트용 Redis 컨테이너.
+ * 컨텍스트를 띄우는 데 필요한 것들을 컨테이너로 준다.
  *
  * <p>{@link JoyingApplicationTests}가 참조하지만 저장소에 없어 테스트 소스가 컴파일되지
- * 않던 클래스다. 컨테이너는 JVM당 한 번만 띄우고 테스트가 끝나면 Ryuk이 정리한다.
+ * 않던 클래스다. 처음에는 주석이 설명하는 대로 Redis만 넣었는데, 그것만으로는 컨텍스트가
+ * 뜨지 않았다. JPA가 붙을 데이터베이스를 찾지 못해 방언을 정하지 못한다.
+ *
+ * <p>MySQL과 MongoDB는 {@code @ServiceConnection}으로 접속 정보가 자동으로 들어간다.
+ * Redis만 다르다. 이 프로젝트의 {@code RedisConfig}가 연결 팩토리를 설정값으로 직접
+ * 만들기 때문에, 스프링이 컨테이너에서 뽑아 주는 접속 정보를 보지 않는다. 그래서
+ * Redis 주소는 테스트에서 설정값으로 직접 넣어 준다.
  */
 @TestConfiguration(proxyBeanMethods = false)
 public class TestcontainersConfiguration {
 
-	private static final GenericContainer<?> REDIS_CONTAINER =
-		new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
-			.withExposedPorts(6379);
+	private static final GenericContainer<?> REDIS =
+		new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
 
 	static {
-		REDIS_CONTAINER.start();
+		REDIS.start();
 	}
 
 	public static GenericContainer<?> getRedisContainer() {
-		return REDIS_CONTAINER;
+		return REDIS;
+	}
+
+	@Bean
+	@ServiceConnection
+	MySQLContainer<?> mysqlContainer() {
+		return new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+			.withDatabaseName("joying_test");
+	}
+
+	@Bean
+	@ServiceConnection
+	MongoDBContainer mongoContainer() {
+		return new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
 	}
 }

--- a/backend/src/test/java/com/joying/chat/broadcast/BroadcastCrossesServersTest.java
+++ b/backend/src/test/java/com/joying/chat/broadcast/BroadcastCrossesServersTest.java
@@ -1,0 +1,216 @@
+package com.joying.chat.broadcast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.broker.SimpleBrokerMessageHandler;
+import org.springframework.messaging.support.ExecutorSubscribableChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+/**
+ * 타이핑과 읽음이 서버를 넘는지 확인한다.
+ *
+ * <p>예전에는 이것들이 발신 서버의 로컬 브로커로 바로 나갔다. 로컬 브로커는 구독 정보를
+ * 자기 메모리에만 들고 있어서 다른 서버에 붙은 상대에게 닿지 않았다. 채팅 메시지 본문만
+ * Redis를 타고 나머지는 전부 빠져 있었다.
+ *
+ * <p>여기서 재현하는 것은 전달 구조다. 서버 두 대를 실제로 띄운 것이 아니라 브로커와
+ * 리스너를 두 벌 만들어 각각을 한 대로 삼았다.
+ */
+class BroadcastCrossesServersTest {
+
+	private static GenericContainer<?> redis;
+	private static RedisConnectionFactory connectionFactory;
+	private static ObjectMapper objectMapper;
+
+	/** 서버 한 대. 자기 브로커와 자기 구독 정보, 자기 리스너를 갖는다. */
+	private static class Server {
+		final ExecutorSubscribableChannel inbound = new ExecutorSubscribableChannel();
+		final ExecutorSubscribableChannel outbound = new ExecutorSubscribableChannel();
+		final ExecutorSubscribableChannel brokerChannel = new ExecutorSubscribableChannel();
+		final SimpMessagingTemplate messagingTemplate;
+		final RedisMessageListenerContainer listenerContainer;
+
+		Server() {
+			SimpleBrokerMessageHandler broker =
+				new SimpleBrokerMessageHandler(inbound, outbound, brokerChannel, null);
+			broker.start();
+			messagingTemplate = new SimpMessagingTemplate(brokerChannel);
+
+			listenerContainer = new RedisMessageListenerContainer();
+			listenerContainer.setConnectionFactory(connectionFactory);
+			listenerContainer.addMessageListener(
+				new ChatBroadcastListener(messagingTemplate, objectMapper),
+				new ChannelTopic(ChatBroadcast.CHANNEL));
+			listenerContainer.afterPropertiesSet();
+			listenerContainer.start();
+		}
+
+		void connectAndSubscribe(String sessionId, String destination, MessageHandler handler) {
+			outbound.subscribe(handler);
+
+			SimpMessageHeaderAccessor connect = SimpMessageHeaderAccessor.create(SimpMessageType.CONNECT);
+			connect.setSessionId(sessionId);
+			inbound.send(MessageBuilder.createMessage(new byte[0], connect.getMessageHeaders()));
+
+			SimpMessageHeaderAccessor sub = SimpMessageHeaderAccessor.create(SimpMessageType.SUBSCRIBE);
+			sub.setSessionId(sessionId);
+			sub.setSubscriptionId("sub-1");
+			sub.setDestination(destination);
+			inbound.send(MessageBuilder.createMessage(new byte[0], sub.getMessageHeaders()));
+		}
+
+		void stop() {
+			try {
+				listenerContainer.stop();
+				listenerContainer.destroy();
+			} catch (Exception ignored) {
+				// 테스트 정리 중 실패는 결과에 영향을 주지 않는다
+			}
+		}
+	}
+
+	/**
+	 * 브로커는 CONNECT 응답도 같은 채널로 보낸다. 목적지가 맞는 MESSAGE만 센다.
+	 */
+	private static MessageHandler countOnly(String destination, CountDownLatch latch,
+											AtomicReference<Object> payload) {
+		return message -> {
+			SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(message);
+			if (SimpMessageType.MESSAGE.equals(accessor.getMessageType())
+				&& destination.equals(accessor.getDestination())) {
+				payload.set(message.getPayload());
+				latch.countDown();
+			}
+		};
+	}
+
+	@BeforeAll
+	static void startRedis() {
+		redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379);
+		redis.start();
+		LettuceConnectionFactory factory =
+			new LettuceConnectionFactory(redis.getHost(), redis.getMappedPort(6379));
+		factory.afterPropertiesSet();
+		connectionFactory = factory;
+		// 애플리케이션의 ObjectMapper와 같은 조건으로 만든다. Kotlin 데이터 클래스를
+		// 읽으려면 클래스패스의 모듈이 등록돼 있어야 하고, 스프링은 그것을 자동으로 한다.
+		objectMapper = JsonMapper.builder().findAndAddModules().build();
+	}
+
+	@AfterAll
+	static void stopRedis() {
+		if (redis != null) {
+			redis.stop();
+		}
+	}
+
+	private ChatBroadcaster broadcasterOnServerA() {
+		return new ChatBroadcaster(new StringRedisTemplate(connectionFactory), objectMapper);
+	}
+
+	@Test
+	@DisplayName("서버 A에서 시작한 타이핑이 서버 B에 붙은 상대에게 닿는다")
+	void typingCrossesServers() throws Exception {
+		Server serverA = new Server();
+		Server serverB = new Server();
+		try {
+			String destination = "/topic/chat/1/typing";
+			CountDownLatch onB = new CountDownLatch(1);
+			AtomicReference<Object> payload = new AtomicReference<>();
+			serverB.connectAndSubscribe("session-b", destination, countOnly(destination, onB, payload));
+
+			broadcasterOnServerA().toTopic(destination, Map.of("chatRoomId", 1, "typing", true));
+
+			assertThat(onB.await(5, TimeUnit.SECONDS))
+				.as("예전에는 여기서 닿지 않았다")
+				.isTrue();
+		} finally {
+			serverA.stop();
+			serverB.stop();
+		}
+	}
+
+	@Test
+	@DisplayName("읽음도 서버를 넘는다")
+	void readReceiptCrossesServers() throws Exception {
+		Server serverA = new Server();
+		Server serverB = new Server();
+		try {
+			String destination = "/topic/chat/7/read";
+			CountDownLatch onB = new CountDownLatch(1);
+			AtomicReference<Object> payload = new AtomicReference<>();
+			serverB.connectAndSubscribe("session-b", destination, countOnly(destination, onB, payload));
+
+			broadcasterOnServerA().toTopic(destination, Map.of("chatRoomId", 7, "readerId", 42));
+
+			assertThat(onB.await(5, TimeUnit.SECONDS)).isTrue();
+		} finally {
+			serverA.stop();
+			serverB.stop();
+		}
+	}
+
+	@Test
+	@DisplayName("페이로드를 문자열이 아니라 객체로 넘긴다. 클라이언트가 두 번 풀지 않아도 된다")
+	void payloadArrivesAsObject() throws Exception {
+		Server serverB = new Server();
+		try {
+			String destination = "/topic/chat/2/typing";
+			CountDownLatch onB = new CountDownLatch(1);
+			AtomicReference<Object> payload = new AtomicReference<>();
+			serverB.connectAndSubscribe("session-b", destination, countOnly(destination, onB, payload));
+
+			broadcasterOnServerA().toTopic(destination, Map.of("chatRoomId", 2, "typing", true));
+
+			assertThat(onB.await(5, TimeUnit.SECONDS)).isTrue();
+
+			// 브로커에 넘어간 것이 문자열이면 클라이언트가 JSON 안의 JSON을 받아
+			// 한 번 더 풀어야 한다. 객체로 넘겨야 그 일이 없다.
+			assertThat(payload.get())
+				.as("문자열이 아니라 객체로 넘어가야 한다")
+				.isInstanceOf(JsonNode.class);
+			assertThat(((JsonNode) payload.get()).get("chatRoomId").asInt()).isEqualTo(2);
+			assertThat(((JsonNode) payload.get()).get("typing").asBoolean()).isTrue();
+		} finally {
+			serverB.stop();
+		}
+	}
+
+	@Test
+	@DisplayName("Redis가 죽어도 부르는 쪽의 작업을 되돌리지 않는다")
+	void publishFailureDoesNotThrow() {
+		LettuceConnectionFactory broken = new LettuceConnectionFactory("127.0.0.1", 1);
+		broken.afterPropertiesSet();
+		ChatBroadcaster broadcaster =
+			new ChatBroadcaster(new StringRedisTemplate(broken), objectMapper);
+
+		broadcaster.toTopic("/topic/chat/1/typing", Map.of("typing", true));
+		broadcaster.toUser(1L, "/queue/chatroom-update", Map.of("roomId", 1));
+		// 예외가 올라오지 않는다. 타이핑 표시가 한 번 빠지는 것보다
+		// 저장된 것을 되돌리는 쪽이 훨씬 비싸다.
+	}
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,34 @@
+# 테스트에서만 쓰는 값.
+#
+# 파일 이름이 application.properties면 메인 설정을 통째로 가린다. 그러면 jwt.secret처럼
+# 여기에 없는 값이 전부 비어 컨텍스트가 뜨지 않는다. 프로파일로 두면 메인 설정 위에
+# 이 값들만 덮인다.
+#
+# 아래는 배포 때 환경변수로 넣던 것들이라 기본값이 없다. 실제로 붙지 않는 자리표시자다.
+# 붙어야 하는 것(MySQL, MongoDB, Redis)은 TestcontainersConfiguration이 컨테이너로
+# 띄우고 접속 정보를 넣는다.
+
+# 파일 저장소
+CLOUDFLARE_R2_ENDPOINT=http://localhost:0
+CLOUDFLARE_R2_ACCESS_KEY=test
+CLOUDFLARE_R2_SECRET_KEY=test
+CLOUDFLARE_R2_BUCKET=test
+CLOUDFLARE_R2_PUBLIC_BASE_URL=http://localhost:0
+
+# 결제
+TOSS_SECRET_KEY=test_sk_dummy
+
+# 검색
+ELASTIC_PASSWORD=test
+spring.elasticsearch.uris=http://localhost:0
+
+# MongoDB 접속 정보는 컨테이너가 넣는다. 아래는 자리만 채운다
+MONGODB_HOST=localhost
+MONGODB_PORT=0
+MONGODB_DATABASE=joying_test
+MONGODB_USERNAME=test
+MONGODB_PASSWORD=test
+
+# 스키마는 컨테이너에 새로 만든다
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.flyway.enabled=false


### PR DESCRIPTION
Closes #19
Base: #18 (refactor/drop-dead-finance-code)

#13에서 재현해 둔 것을 고친다.

## 목적지마다 붙이지 않았다

하나씩 더하면 새 목적지가 생길 때마다 또 잊는다. 메시지 본문만 붙어 있고 나머지 열 곳이 빠져 있던 것이 그 결과다.

```
ChatBroadcaster        나가는 자리. toUser와 toTopic 둘뿐이다
ChatBroadcastListener  각 서버가 받아 자기에게 붙은 세션에만 내보낸다
```

보내는 쪽은 로컬 브로커를 직접 부르지 않는다. Redis Pub/Sub은 발행자에게도 되돌려 주므로, 직접 부르면 자기 서버에 붙은 사람에게 두 번 간다.

## 갈아 끼운 곳

| 무엇 | 어디 |
|---|---|
| 타이핑, 읽음 | `ChatWebSocketHandler` 2곳 |
| 방 목록 갱신, 알림, 방 상태 | `ChatService` 3곳 |
| 방 상태 변경 | `ChatRoomService` 4곳 |
| 접속 상태 | `ChatPresenceService` 1곳 |

## 실측

| 무엇을 쟀나 | 결과 |
|---|---|
| 서버 A의 타이핑이 서버 B에 닿는가 | 닿는다 |
| 읽음도 넘어가는가 | 넘어간다 |
| 페이로드가 문자열이 아니라 객체로 오는가 | 객체로 온다 |
| Redis가 죽어도 부르는 쪽이 안 터지는가 | 안 터진다 |

## 컨텍스트 테스트를 처음으로 통과시켰다

빈 배선이 여러 곳 바뀌어서 컨텍스트가 실제로 뜨는지 확인할 자리가 필요했다. 그동안 그 테스트는 컴파일만 되고 돌지 않았다.

- MySQL·MongoDB는 컨테이너로 띄워 접속 정보를 자동으로 넣는다
- **Redis만 다르다.** `RedisConfig`가 연결 팩토리를 설정값으로 직접 만들어 스프링이 컨테이너에서 뽑아 주는 접속 정보를 보지 않는다
- 테스트 설정 파일을 `application.properties`로 두면 **메인 설정을 통째로 가려** `jwt.secret` 같은 값이 전부 빈다. 프로파일로 분리했다
- `TossPaymentsClientImpl`이 `@Profile({"prod","local"})`이라 test만으로는 결제 배선이 통째로 빠진다

## 확인

클린 빌드 통과. 테스트 29개 통과.