### PR TITLE
refactor: 보증금이 플랫폼 장부를 지나지 않게 한다

### DIFF
--- a/backend/src/main/java/com/joying/escrow/service/EscrowService.java
+++ b/backend/src/main/java/com/joying/escrow/service/EscrowService.java
@@ -4,6 +4,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import com.joying.escrow.domain.Escrow;
 import com.joying.wallet.port.TransferOutcome;
+import com.joying.payment.port.DepositHoldPort;
 import com.joying.wallet.port.MoneyTransferPort;
 import com.joying.escrow.dto.request.EscrowCreateRequest;
 import com.joying.escrow.dto.response.EscrowResponse;
@@ -31,6 +32,7 @@ public class EscrowService {
     private final RentalHistoryRepository rentalHistoryRepository;
     private final PaymentRepository paymentRepository;
     private final MoneyTransferPort moneyTransferPort;
+    private final DepositHoldPort depositHoldPort;
 
     /**
      * 에스크로 홀드 생성 (결제 완료 후)
@@ -161,21 +163,34 @@ public class EscrowService {
             }
         }
 
-        // 보증금 반환 (중개 지갑 → 차용자 지갑)
+        // 보증금 반환은 송금이 아니다.
+        //
+        // 예전에는 중개 지갑에서 차용자 지갑으로 옮겼다. 그러려면 차용자의 계좌를 알아야
+        // 하고, 옮기다 실패하면 우리가 책임져야 하고, 그 일 자체가 정산 대행이 되어
+        // 전자지급결제대행업 등록 대상이 된다.
+        //
+        // 보증금은 결제에 그대로 남아 있으므로 카드에서 직접 되돌린다. 받는 사람의
+        // 계좌를 알 필요도, 우리가 그 돈을 들고 있을 필요도 없다.
         if (!escrow.isDepositReturned()) {
-            TransferOutcome outcome = moneyTransferPort.transferFromEscrow(
-                    renter.getMemberId(),
+            String paymentKey = escrow.getPayment() == null ? null : escrow.getPayment().getPaymentKey();
+            if (paymentKey == null) {
+                log.error("[보증금 반환 불가 - 결제 정보 없음] holdId={}", holdId);
+                return convertToResponse(escrow);
+            }
+
+            TransferOutcome outcome = depositHoldPort.release(
+                    paymentKey,
                     escrow.getDepositAmount().longValue(),
-                    "settle-deposit-" + escrow.getHoldId(),
-                    "Joying 보증금 반환"
+                    "deposit-release-" + escrow.getHoldId(),
+                    "대여 정상 종료에 따른 보증금 반환"
             );
 
             if (outcome instanceof TransferOutcome.Succeeded succeeded) {
                 escrow.markDepositReturned(succeeded.transferId(),
                         Timestamp.from(Instant.now()));
-                log.info("[보증금 반환 완료] rentalHisId={}, txNo={}, amount={}, to={}",
+                log.info("[보증금 반환 요청 완료] rentalHisId={}, ref={}, amount={}, via={}",
                         rental.getRentalHisId(), succeeded.transferId(),
-                        escrow.getDepositAmount(), renter.getMemberId());
+                        escrow.getDepositAmount(), depositHoldPort.name());
             } else {
                 // 대여료는 이미 나갔고 그 기록이 남아 있다. 다시 돌리면 여기서부터 이어간다.
                 log.error("[보증금 반환 미완료 - 정산 중단] holdId={}, rentalHisId={}, outcome={}",
@@ -184,7 +199,7 @@ public class EscrowService {
             }
         }
 
-        // 6. 두 송금이 모두 확정됐을 때만 정산을 닫는다
+        // 대여료 지급과 보증금 반환이 모두 처리됐을 때만 정산을 닫는다
         escrow.settle();
 
         // 7. RentalHistory 상태 업데이트 (RETURNED → DEPOSIT_RETURNED)

--- a/backend/src/main/java/com/joying/payment/adapter/deposit/FullCaptureDepositHoldAdapter.java
+++ b/backend/src/main/java/com/joying/payment/adapter/deposit/FullCaptureDepositHoldAdapter.java
@@ -1,0 +1,107 @@
+package com.joying.payment.adapter.deposit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.joying.payment.exception.TossPaymentException;
+import com.joying.payment.port.DepositHoldPort;
+import com.joying.payment.port.TossPaymentsClient;
+import com.joying.wallet.port.TransferOutcome;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 보증금까지 결제 시점에 매입된 상태에서 다루는 구현.
+ *
+ * <p>보증금을 승인만 하고 매입을 미루는 것(수동매입)은 PG와 계약할 때 정하는 설정이라
+ * 코드로 켤 수 없다. 그래서 지금은 결제 전액이 매입된 채로 시작하고, 보증금을 푸는 것이
+ * 부분취소가 된다.
+ *
+ * <p>수동매입을 쓸 수 있게 되면 이 자리에 다른 구현을 넣는다. 부르는 쪽은 그대로다.
+ * 달라지는 것은 고객에게 보이는 모습뿐이다. 매입을 미루면 한도만 잡혔다 풀리고,
+ * 지금은 청구됐다가 돌아온다.
+ *
+ * <p>플랫폼 장부를 지나지 않는다는 점은 두 구현이 같다. 보증금은 어느 쪽에서도
+ * 우리 원장에 적히지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FullCaptureDepositHoldAdapter implements DepositHoldPort {
+
+	private final TossPaymentsClient tossClient;
+
+	/**
+	 * 승인일로부터 매입을 요청할 수 있는 기간이 30일이다. 반납과 확인에 쓸 여유를 빼고
+	 * 대여 기간 상한으로 삼는다. 이 값을 늘리려면 PG 약관을 다시 봐야 한다.
+	 */
+	@Value("${joying.rental.max-period-days:21}")
+	private int maxRentalPeriodDays;
+
+	@Override
+	public TransferOutcome release(String paymentKey, long depositAmount,
+								   String reference, String reason) {
+		return cancel(paymentKey, depositAmount, reference, reason, "보증금 반환");
+	}
+
+	@Override
+	public TransferOutcome claim(String paymentKey, long depositAmount, long claimAmount,
+								 String reference, String reason) {
+		if (claimAmount < 0 || claimAmount > depositAmount) {
+			return new TransferOutcome.Rejected("INVALID_CLAIM_AMOUNT",
+				"배상액이 보증금 범위를 벗어난다: claim=" + claimAmount + ", deposit=" + depositAmount);
+		}
+
+		long refundAmount = depositAmount - claimAmount;
+		if (refundAmount == 0) {
+			// 보증금 전액이 배상으로 확정됐다. 되돌릴 것이 없다.
+			log.info("[보증금] 전액 배상으로 확정: paymentKey={}, amount={}", paymentKey, claimAmount);
+			return new TransferOutcome.Succeeded("no-refund:" + reference);
+		}
+		return cancel(paymentKey, refundAmount, reference, reason, "보증금 일부 반환");
+	}
+
+	private TransferOutcome cancel(String paymentKey, long amount,
+								   String reference, String reason, String what) {
+		if (amount <= 0) {
+			return new TransferOutcome.Rejected("INVALID_AMOUNT", "되돌릴 금액이 0 이하다: " + amount);
+		}
+
+		try {
+			var response = tossClient.cancelPartial(paymentKey, reason, amount, reference);
+			log.info("[보증금] {} 요청함: paymentKey={}, amount={}, reference={}",
+				what, paymentKey, amount, reference);
+
+			// 부분취소는 매입 뒤에 도는 절차라 요청한 자리에서 끝나지 않는다. 카드사에
+			// 반영되기까지 영업일이 걸리므로, 여기서 돌려주는 성공은 "요청이 받아들여졌다"는
+			// 뜻이지 "고객 카드에 반영됐다"는 뜻이 아니다. 반영 확인은 따로 해야 한다.
+			return new TransferOutcome.Succeeded(
+				response == null ? reference : String.valueOf(response.getStatus()));
+
+		} catch (TossPaymentException e) {
+			// 카드사가 요청을 받고 거절했다. 돈은 그대로다.
+			log.error("[보증금] {} 거절: paymentKey={}, code={}, message={}",
+				what, paymentKey, e.getCode(), e.getMessage());
+			return new TransferOutcome.Rejected(e.getCode(), e.getMessage());
+
+		} catch (Exception e) {
+			// 응답을 못 받았다. 취소가 걸렸는지 알 수 없으므로 다시 보내면 안 되고,
+			// 같은 열쇠로 다시 물어 확인해야 한다.
+			log.error("[보증금] {} 결과 미확정: paymentKey={}, reference={}",
+				what, paymentKey, reference, e);
+			return new TransferOutcome.Unconfirmed(
+				e.getClass().getSimpleName() + ": " + e.getMessage());
+		}
+	}
+
+	@Override
+	public String name() {
+		return "full-capture";
+	}
+
+	@Override
+	public int holdLimitDays() {
+		return maxRentalPeriodDays;
+	}
+}

--- a/backend/src/main/java/com/joying/payment/adapter/toss/TossPaymentsClientImpl.java
+++ b/backend/src/main/java/com/joying/payment/adapter/toss/TossPaymentsClientImpl.java
@@ -124,6 +124,52 @@ public class TossPaymentsClientImpl implements TossPaymentsClient {
         }
     }
 
+    @Override
+    public TossCancelResponse cancelPartial(String paymentKey, String reason, long cancelAmount,
+                                            String idempotencyKey) {
+        log.info("[Toss API] 결제 부분취소 요청: paymentKey={}, amount={}, key={}",
+                paymentKey, cancelAmount, idempotencyKey);
+
+        try {
+            TossCancelRequest request = new TossCancelRequest(reason);
+            request.setCancelAmount((int) cancelAmount);
+
+            TossCancelResponse response = tossWebClient.post()
+                    .uri("/v1/payments/{paymentKey}/cancel", paymentKey)
+                    .header(HttpHeaders.AUTHORIZATION, "Basic " + basic(secretKey + ":"))
+                    // 같은 열쇠로 두 번 보내면 토스가 첫 응답을 그대로 돌려준다.
+                    // 재시도가 두 번 취소되지 않게 하는 것은 우리 코드가 아니라 이 헤더다.
+                    .header("Idempotency-Key", idempotencyKey)
+                    .bodyValue(request)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                            clientResponse.bodyToMono(String.class)
+                                    .flatMap(errorBody -> {
+                                        log.error("[Toss API] 4xx 에러: {}", errorBody);
+                                        return Mono.error(new TossPaymentException("CLIENT_ERROR", errorBody));
+                                    })
+                    )
+                    .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                            clientResponse.bodyToMono(String.class)
+                                    .flatMap(errorBody -> {
+                                        log.error("[Toss API] 5xx 에러: {}", errorBody);
+                                        return Mono.error(new TossPaymentException("SERVER_ERROR", errorBody));
+                                    })
+                    )
+                    .bodyToMono(TossCancelResponse.class)
+                    .block();
+
+            log.info("[Toss API] 결제 부분취소 성공: paymentKey={}, status={}",
+                    paymentKey, response == null ? null : response.getStatus());
+            return response;
+
+        } catch (WebClientResponseException e) {
+            log.error("[Toss API] 결제 부분취소 실패: status={}, body={}",
+                    e.getStatusCode(), e.getResponseBodyAsString());
+            throw new TossPaymentException("CANCEL_FAILED", e.getResponseBodyAsString());
+        }
+    }
+
     /**
      * orderId로 결제 조회 (멱등성 처리용)
      */

--- a/backend/src/main/java/com/joying/payment/dto/request/TossCancelRequest.java
+++ b/backend/src/main/java/com/joying/payment/dto/request/TossCancelRequest.java
@@ -2,7 +2,22 @@ package com.joying.payment.dto.request;
 
 import lombok.*;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 @Getter@Setter@AllArgsConstructor@NoArgsConstructor@Builder
 public class TossCancelRequest {
+
     private String cancelReason;
+
+    /**
+     * 취소할 금액. 비워 두면 전액 취소다.
+     *
+     * <p>보증금만 풀 때처럼 결제 일부만 되돌려야 하는 경우에 쓴다.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Integer cancelAmount;
+
+    public TossCancelRequest(String cancelReason) {
+        this.cancelReason = cancelReason;
+    }
 }

--- a/backend/src/main/java/com/joying/payment/port/DepositHoldPort.java
+++ b/backend/src/main/java/com/joying/payment/port/DepositHoldPort.java
@@ -1,0 +1,53 @@
+package com.joying.payment.port;
+
+import com.joying.wallet.port.TransferOutcome;
+
+/**
+ * 보증금을 잡아 두고 나중에 풀거나 일부만 확정하는 경계.
+ *
+ * <p>보증금은 얼마를 돌려줄지가 나중에 정해지는 돈이다. 그래서 결제 시점에 플랫폼
+ * 장부로 옮기지 않는다. 옮기는 순간 그 돈은 우리가 책임지는 돈이 되고, 정산에 관여하는
+ * 것이 되어 전자지급결제대행업 등록 대상이 된다.
+ *
+ * <p>카드 결제는 승인과 매입이 나뉘어 있다. 승인만 하면 한도만 잡히고 청구되지 않으며,
+ * 매입해야 실제로 가맹점에 돈이 온다. 이 성질을 그대로 쓴다.
+ *
+ * <ul>
+ *   <li>정상 반납이면 승인을 취소한다. 청구된 적이 없으므로 되돌릴 것도 없다.
+ *   <li>파손이면 배상액만 확정한다. 나머지는 풀린다.
+ * </ul>
+ *
+ * <p>구현이 둘이다. 수동매입을 쓸 수 있으면 위 설명 그대로 돈다. 쓸 수 없으면 결제
+ * 시점에 전액이 매입되므로, 푸는 것이 취소가 되고 확정하는 것이 부분취소가 된다.
+ * 부르는 쪽에서 보면 같고, 고객에게 보이는 것만 다르다.
+ */
+public interface DepositHoldPort {
+
+	/**
+	 * 보증금을 통째로 푼다. 정상 반납일 때 부른다.
+	 *
+	 * @param reference 이 처리를 가리키는 값. 같은 값으로 두 번 불러도 한 번만 처리된다
+	 */
+	TransferOutcome release(String paymentKey, long depositAmount, String reference, String reason);
+
+	/**
+	 * 보증금 중 일부만 확정하고 나머지를 푼다. 파손일 때 부른다.
+	 *
+	 * @param claimAmount 확정할 금액. 0이면 {@link #release}와 같다
+	 */
+	TransferOutcome claim(String paymentKey, long depositAmount, long claimAmount,
+						  String reference, String reason);
+
+	/**
+	 * 이 구현이 보증금을 어떻게 다루는지. 로그와 운영 화면에서 구분하는 데 쓴다.
+	 */
+	String name();
+
+	/**
+	 * 승인일로부터 이 일수 안에 보증금을 확정하거나 풀어야 한다.
+	 *
+	 * <p>대여 기간이 이 한도를 넘으면 반납 시점에 카드를 건드릴 수 없다. 그래서 결제를
+	 * 받기 전에 막아야 하고, 이 값이 곧 대여 기간의 상한이 된다.
+	 */
+	int holdLimitDays();
+}

--- a/backend/src/main/java/com/joying/payment/port/TossPaymentsClient.java
+++ b/backend/src/main/java/com/joying/payment/port/TossPaymentsClient.java
@@ -8,6 +8,18 @@ public interface TossPaymentsClient {
     TossCancelResponse cancel(String paymentKey, String reason);
 
     /**
+     * 결제의 일부만 취소한다.
+     *
+     * <p>보증금처럼 나중에 얼마를 돌려줄지 정해지는 금액을 다룰 때 쓴다.
+     *
+     * @param cancelAmount   되돌릴 금액
+     * @param idempotencyKey 같은 취소를 두 번 보내도 한 번만 처리되게 하는 열쇠.
+     *                       재시도는 같은 값을, 서로 다른 부분취소는 다른 값을 쓴다
+     */
+    TossCancelResponse cancelPartial(String paymentKey, String reason, long cancelAmount,
+                                     String idempotencyKey);
+
+    /**
      * orderId로 결제 조회 (멱등성 처리용)
      * @param orderId 주문 ID
      * @return 결제 정보

--- a/backend/src/main/java/com/joying/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/joying/payment/service/PaymentService.java
@@ -1,5 +1,6 @@
 package com.joying.payment.service;
 
+import java.time.Duration;
 import com.joying.member.domain.Member;
 import com.joying.member.repository.MemberRepository;
 import com.joying.payment.domain.Payment;
@@ -22,6 +23,7 @@ import com.joying.rental.domain.RentalHistory;
 import com.joying.rental.repository.RentalHistoryRepository;
 import com.joying.escrow.domain.Escrow;
 import com.joying.wallet.port.TransferOutcome;
+import com.joying.payment.port.DepositHoldPort;
 import com.joying.wallet.port.MoneyTransferPort;
 import com.joying.escrow.repository.EscrowRepository;
 import lombok.RequiredArgsConstructor;
@@ -63,6 +65,7 @@ public class PaymentService {
     private final TossPaymentsClient tossClient;
     private final ApplicationEventPublisher eventPublisher;
     private final MoneyTransferPort moneyTransferPort;
+    private final DepositHoldPort depositHoldPort;
 
     /**
      * 1. 결제 생성 (orderId 발급)
@@ -374,6 +377,13 @@ public class PaymentService {
         RentalHistory rentalHistory = payment.getRentalHistory();
 
         // PaymentType에 따라 분기 처리
+        // 대여 기간이 보증금을 붙잡아 둘 수 있는 기간을 넘으면 받지 않는다.
+        //
+        // 반납 시점에 카드를 건드릴 수 없으면 보증금을 돌려줄 방법이 사라진다. 그때
+        // 남는 선택지는 우리가 대신 보내는 것뿐이고, 그것을 피하려고 이 구조를 만들었다.
+        // 그래서 결제를 받기 전에 막는다. 기술이 아니라 서비스가 정하는 상한이다.
+        rejectIfRentalPeriodExceedsHoldLimit(rentalHistory);
+
         if (payment.getPaymentType() == PaymentType.INITIAL) {
             // 최초 결제: RentalHistory 상태 업데이트 (ESCROW) + Escrow 생성
             rentalHistory.markAsEscrow();
@@ -390,46 +400,47 @@ public class PaymentService {
                 log.info("Escrow 생성 완료: escrowId={}, paymentId={}, rentalFee={}, deposit={}",
                         escrow.getHoldId(), payment.getPaymentId(), totalRentalFee, depositAmount);
 
-                // 토스 결제 완료 후 Joying 에스크로 계좌로 입금 (SSAFY 금융망)
-                // 실제 돈은 토스에 있고, SSAFY 금융망에는 논리적으로만 입금
-                // 실제 결제 금액 = (일일요금 × 일수) + 보증금 (payment.getTotalAmount()에 저장됨)
-                long totalAmount = payment.getTotalAmount().longValue();
+                // 대여료만 중개 장부에 적립한다.
+                //
+                // 예전에는 보증금까지 전액을 적립했다. 보증금은 얼마를 돌려줄지가 나중에
+                // 정해지는 돈이라, 우리 장부로 옮기는 순간 우리가 책임지는 돈이 된다.
+                // 그리고 그것을 대여자에게 보내는 일이 정산 대행이 되어 전자지급결제
+                // 대행업 등록 대상이 된다.
+                //
+                // 보증금은 결제에 그대로 남겨 두고 금액만 기록한다. 반납이 확정되면
+                // 카드에서 직접 풀거나 배상액만 확정한다. 플랫폼 장부를 지나지 않는다.
+                long rentalFeeAmount = totalRentalFee.longValue();
 
                 // 주문번호를 참조로 쓴다. 같은 주문으로 두 번 불러도 돈은 한 번만 움직인다.
                 TransferOutcome outcome = moneyTransferPort.creditToEscrow(
-                        totalAmount,
-                        "escrow-deposit-" + payment.getOrderId(),
-                        "Toss 결제 에스크로 입금 (orderId: " + payment.getOrderId() + ")"
+                        rentalFeeAmount,
+                        "rental-fee-" + payment.getOrderId(),
+                        "대여료 적립 (orderId: " + payment.getOrderId() + ")"
                 );
 
                 if (outcome instanceof TransferOutcome.Succeeded succeeded) {
                     escrow.markHeld(succeeded.transferId());
-                    log.info("[에스크로 적립 완료] rentalHisId={}, transferId={}, amount={}, via={}",
+                    log.info("[대여료 적립 완료] rentalHisId={}, transferId={}, amount={}, via={}",
                             rentalHistory.getRentalHisId(), succeeded.transferId(),
-                            totalAmount, moneyTransferPort.name());
+                            rentalFeeAmount, moneyTransferPort.name());
 
                 } else if (outcome instanceof TransferOutcome.Rejected rejected) {
                     // 상대가 요청을 받고 거절했다. 돈은 옮겨지지 않은 것이 확정이므로,
                     // 이미 승인된 토스 결제를 되돌리는 것이 맞다.
-                    log.error("[에스크로 적립 거절] orderId={}, code={}, reason={}",
+                    log.error("[대여료 적립 거절] orderId={}, code={}, reason={}",
                             payment.getOrderId(), rejected.reasonCode(), rejected.reason());
                     cancelTossPaymentForFailedDeposit(payment, tossResponse.getPaymentKey(),
-                            "에스크로 적립 거절");
-                    throw new IllegalStateException("에스크로 적립이 거절되었습니다: "
+                            "대여료 적립 거절");
+                    throw new IllegalStateException("대여료 적립이 거절되었습니다: "
                             + rejected.reasonCode());
 
                 } else {
                     // 옮겨졌는지 알 수 없다. 여기서 토스 결제를 취소하면 실제로 적립이
-                    // 성공했을 때 고객 돈만 돌아가고 에스크로에는 돈이 남는다. 되돌리지
-                    // 않고 PENDING으로 남겨 두었다가 재조회가 확정한다. 예외를 던지지
-                    // 않는 이유는, 롤백하면 방금 남긴 PENDING 행까지 같이 사라져
-                    // 나중에 이 건을 찾을 방법이 없어지기 때문이다.
-                    //
-                    // 내부 원장 구현에서는 이 갈래로 오지 않는다. 밖으로 나가는 구현으로
-                    // 바꿔도 코드가 그대로 맞도록 남겨 둔다.
+                    // 성공했을 때 고객 돈만 돌아간다. 되돌리지 않고 PENDING으로 남긴다.
                     TransferOutcome.Unconfirmed unconfirmed = (TransferOutcome.Unconfirmed) outcome;
-                    log.warn("[에스크로 적립 미확정 - 재조회 대상] orderId={}, escrowId={}, amount={}, reason={}",
-                            payment.getOrderId(), escrow.getHoldId(), totalAmount, unconfirmed.reason());
+                    log.warn("[대여료 적립 미확정 - 재조회 대상] orderId={}, escrowId={}, amount={}, reason={}",
+                            payment.getOrderId(), escrow.getHoldId(), rentalFeeAmount,
+                            unconfirmed.reason());
                 }
             }
 
@@ -559,6 +570,29 @@ public class PaymentService {
         } catch (Exception cancelEx) {
             log.error("[Toss 결제 취소 실패 - 수동 처리 필요] orderId={}, paymentKey={}",
                     payment.getOrderId(), paymentKey, cancelEx);
+        }
+    }
+
+
+    /**
+     * 대여 기간이 보증금 보류 한도를 넘으면 결제를 막는다.
+     *
+     * <p>승인일로부터 매입을 요청할 수 있는 기간이 정해져 있어, 그보다 긴 대여는 반납
+     * 시점에 카드를 건드릴 수 없다.
+     */
+    private void rejectIfRentalPeriodExceedsHoldLimit(RentalHistory rentalHistory) {
+        if (rentalHistory.getStartRen() == null || rentalHistory.getEndRen() == null) {
+            return;
+        }
+        long days = Duration.between(
+                rentalHistory.getStartRen().toInstant(),
+                rentalHistory.getEndRen().toInstant()).toDays();
+        int limit = depositHoldPort.holdLimitDays();
+        if (days > limit) {
+            log.warn("[대여 기간 초과] rentalHisId={}, days={}, limit={}",
+                    rentalHistory.getRentalHisId(), days, limit);
+            throw new IllegalStateException(
+                    "대여 기간이 " + limit + "일을 넘어 결제할 수 없습니다: " + days + "일");
         }
     }
 

--- a/backend/src/main/java/com/joying/rental/service/RentalService.java
+++ b/backend/src/main/java/com/joying/rental/service/RentalService.java
@@ -1,6 +1,7 @@
 package com.joying.rental.service;
 
 import com.joying.wallet.port.TransferOutcome;
+import com.joying.payment.port.DepositHoldPort;
 import com.joying.wallet.port.MoneyTransferPort;
 import com.joying.escrow.domain.Status;
 import com.joying.file.component.FileUrlResolver;
@@ -71,6 +72,7 @@ public class RentalService {
     private final PaymentRepository paymentRepository;
     private final PaymentService paymentService;
     private final MoneyTransferPort moneyTransferPort;
+    private final DepositHoldPort depositHoldPort;
     private final DevModeProperties devModeProperties;
 
     /**
@@ -868,21 +870,33 @@ public class RentalService {
             // 확정된 송금은 거래고유번호를 남겨 두고, 다시 돌 때 그 단계를 건너뛴다.
             // 확정한 뒤에는 예외를 던지지 않는다. 던지면 방금 남긴 기록까지 같이 사라진다.
 
-            // 대여료 + 차용자 보증금 몫 → 차용자에게 환불
+            // 차용자에게 돌려줄 몫은 카드에서 직접 되돌린다.
+            //
+            // 예전에는 중개 지갑에서 차용자 지갑으로 옮겼다. 그러려면 차용자의 계좌를
+            // 알아야 하고, 그 일 자체가 정산 대행이 되어 등록 대상이 된다. 되돌릴 돈은
+            // 왔던 길로 보내면 되고, 그러면 우리가 그 돈을 만질 일이 없다.
             if (!cancel.isRenterRefundSent()) {
                 long renterRefundAmt = escrow.getRentalFee() + cancel.getDepositRenterAmt();
-                TransferOutcome outcome = moneyTransferPort.transferFromEscrow(
-                        renter.getMemberId(),
+                String paymentKey = escrow.getPayment() == null
+                        ? null : escrow.getPayment().getPaymentKey();
+
+                if (paymentKey == null) {
+                    log.error("[차용자 환불 불가 - 결제 정보 없음] rentalHisId={}", rentalHisId);
+                    return convertToCancelResponse(cancel);
+                }
+
+                TransferOutcome outcome = depositHoldPort.release(
+                        paymentKey,
                         renterRefundAmt,
                         "cancel-renter-" + cancel.getCancelId(),
-                        "Joying 취소 환불 (대여료+보증금)"
+                        "대여 취소에 따른 환불"
                 );
 
                 if (outcome instanceof TransferOutcome.Succeeded succeeded) {
                     cancel.markRenterRefundSent(succeeded.transferId());
-                    log.info("[차용자 환불 완료] rentalHisId={}, transferId={}, amount={}, toMemberId={}",
+                    log.info("[차용자 환불 요청 완료] rentalHisId={}, ref={}, amount={}, via={}",
                             rentalHisId, succeeded.transferId(), renterRefundAmt,
-                            renter.getMemberId());
+                            depositHoldPort.name());
                 } else {
                     log.error("[차용자 환불 미완료 - 환불 중단] rentalHisId={}, outcome={}",
                             rentalHisId, outcome);

--- a/backend/src/test/java/com/joying/payment/DepositHoldTest.java
+++ b/backend/src/test/java/com/joying/payment/DepositHoldTest.java
@@ -1,0 +1,117 @@
+package com.joying.payment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+
+import com.joying.payment.adapter.deposit.FullCaptureDepositHoldAdapter;
+import com.joying.payment.exception.TossPaymentException;
+import com.joying.payment.port.TossPaymentsClient;
+import com.joying.wallet.port.TransferOutcome;
+
+/**
+ * 보증금을 카드에서 되돌리는 경로.
+ *
+ * <p>보증금은 플랫폼 장부를 지나지 않는다. 받는 사람의 계좌를 몰라도 되고, 우리가 그
+ * 돈을 들고 있지도 않는다. 대신 되돌리는 요청이 정확해야 한다. 금액을 잘못 넣으면
+ * 대여료까지 같이 돌아가고, 두 번 보내면 두 번 돌아간다.
+ */
+@ExtendWith(MockitoExtension.class)
+class DepositHoldTest {
+
+	private static final String PAYMENT_KEY = "payment-key-1";
+
+	@Mock
+	TossPaymentsClient tossClient;
+
+	@InjectMocks
+	FullCaptureDepositHoldAdapter adapter;
+
+	@Test
+	@DisplayName("정상 반납이면 보증금 전액을 되돌린다")
+	void releasesWholeDeposit() {
+		adapter.release(PAYMENT_KEY, 300_000L, "deposit-release-1", "정상 반납");
+
+		ArgumentCaptor<Long> amount = ArgumentCaptor.forClass(Long.class);
+		verify(tossClient).cancelPartial(anyString(), anyString(), amount.capture(), anyString());
+		assertThat(amount.getValue()).isEqualTo(300_000L);
+	}
+
+	@Test
+	@DisplayName("파손이면 배상액을 뺀 나머지만 되돌린다")
+	void refundsOnlyTheRemainderWhenClaimed() {
+		adapter.claim(PAYMENT_KEY, 300_000L, 80_000L, "deposit-claim-1", "파손 배상");
+
+		ArgumentCaptor<Long> amount = ArgumentCaptor.forClass(Long.class);
+		verify(tossClient).cancelPartial(anyString(), anyString(), amount.capture(), anyString());
+		assertThat(amount.getValue())
+			.as("배상액은 남기고 나머지만 돌아간다")
+			.isEqualTo(220_000L);
+	}
+
+	@Test
+	@DisplayName("보증금 전액이 배상으로 확정되면 카드를 건드리지 않는다")
+	void doesNotCallCardWhenNothingToRefund() {
+		TransferOutcome outcome = adapter.claim(PAYMENT_KEY, 300_000L, 300_000L,
+			"deposit-claim-2", "전손");
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Succeeded.class);
+		verify(tossClient, never()).cancelPartial(anyString(), anyString(), anyLong(), anyString());
+	}
+
+	@Test
+	@DisplayName("배상액이 보증금을 넘으면 거절한다. 대여료까지 되돌리면 안 된다")
+	void rejectsClaimBeyondDeposit() {
+		TransferOutcome outcome = adapter.claim(PAYMENT_KEY, 300_000L, 300_001L,
+			"deposit-claim-3", "과다 청구");
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Rejected.class);
+		assertThat(((TransferOutcome.Rejected) outcome).reasonCode()).isEqualTo("INVALID_CLAIM_AMOUNT");
+		verify(tossClient, never()).cancelPartial(anyString(), anyString(), anyLong(), anyString());
+	}
+
+	@Test
+	@DisplayName("같은 처리에는 같은 열쇠를 보낸다. 재시도가 두 번 되돌리지 않게 하는 건 이 열쇠다")
+	void sendsReferenceAsIdempotencyKey() {
+		adapter.release(PAYMENT_KEY, 300_000L, "deposit-release-42", "정상 반납");
+
+		ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+		verify(tossClient).cancelPartial(anyString(), anyString(), anyLong(), key.capture());
+		assertThat(key.getValue()).isEqualTo("deposit-release-42");
+	}
+
+	@Test
+	@DisplayName("카드사가 거절하면 확정 실패다. 돈은 그대로다")
+	void rejectedWhenCardCompanyRefuses() {
+		given(tossClient.cancelPartial(anyString(), anyString(), anyLong(), anyString()))
+			.willThrow(new TossPaymentException("EXCEED_CANCEL_AMOUNT", "취소 가능 금액을 초과했습니다"));
+
+		TransferOutcome outcome = adapter.release(PAYMENT_KEY, 300_000L, "deposit-release-2", "정상 반납");
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Rejected.class);
+		assertThat(((TransferOutcome.Rejected) outcome).reasonCode()).isEqualTo("EXCEED_CANCEL_AMOUNT");
+	}
+
+	@Test
+	@DisplayName("응답을 못 받으면 미확정이다. 되돌렸는지 알 수 없으니 다시 보내면 안 된다")
+	void unconfirmedWhenNoResponse() {
+		given(tossClient.cancelPartial(anyString(), anyString(), anyLong(), anyString()))
+			.willThrow(new RuntimeException("Read timed out"));
+
+		TransferOutcome outcome = adapter.release(PAYMENT_KEY, 300_000L, "deposit-release-3", "정상 반납");
+
+		assertThat(outcome).isInstanceOf(TransferOutcome.Unconfirmed.class);
+	}
+}


### PR DESCRIPTION
Closes #21
Base: #20 (fix/broadcast-across-servers)

## 왜

**정산에 관여하면 전자지급결제대행업 등록 대상이다.** 금융위는 플랫폼이 정산을 직접 처리하지 않고 외부 PG사가 전담하면 등록이 필요 없다고 본다.

그리고 보증금은 애초에 옮길 필요가 없는 돈이었다. **얼마를 돌려줄지가 나중에 정해지므로**, 결제에 그대로 두었다가 정해질 때 카드에서 직접 처리하면 된다.

## 무엇이 바뀌나

| | 전 | 후 |
|---|---|---|
| 결제 시 적립 | 대여료 + 보증금 전액 | **대여료만** |
| 보증금 반환 | 중개 지갑 → 차용자 지갑 송금 | **카드에서 되돌림** |
| 취소 환불 | 차용자 지갑으로 송금 | **카드에서 되돌림** |
| 차용자 계좌 | 필요 | **불필요** |
| 대여 기간 | 제한 없음 | 보증금 보류 한도 안에서만 |

**차용자에게 보내는 송금이 통째로 사라진다.**

## DepositHoldPort로 뽑은 이유

보증금을 승인만 하고 매입을 미루는 것(수동매입)은 PG 계약 설정이라 코드로 켤 수 없다. 지금은 전액이 매입된 채로 시작하므로 푸는 것이 부분취소가 된다.

계약이 열리면 구현만 갈아 끼운다. 달라지는 건 고객에게 보이는 모습뿐이다 — 매입을 미루면 한도만 잡혔다 풀리고, 지금은 청구됐다가 돌아온다. **플랫폼 장부를 지나지 않는다는 점은 두 구현이 같다.**

## C2C라서 남는 것

렌터카는 차 주인이 곧 가맹점이라 배상액을 확정하면 끝난다. C2C는 플랫폼이 가맹점이고 **피해자는 대여자**라서, 배상액과 대여료는 여전히 대여자에게 가야 한다. 그 경로는 지갑이 대신하고 있고 PG 지급대행으로 넘기는 건 계약이 필요해 아직 못 한다.

## 실측

보증금 처리 테스트 7개. 전액 반환, 배상액만 남기기, 전손 시 카드 미호출, 배상액이 보증금을 넘으면 거절, 같은 열쇠로 재시도, 거절과 미확정 구분.

클린 빌드 통과. 전체 테스트 36개 통과.