### PR TITLE
feat: 취소 요청과 취소 확정을 구분하고 매일 대사한다

### DIFF
--- a/backend/src/main/java/com/joying/escrow/domain/Escrow.java
+++ b/backend/src/main/java/com/joying/escrow/domain/Escrow.java
@@ -71,6 +71,14 @@ public class Escrow {
     @Column(name = "rental_fee_released_at")
     private Timestamp rentalFeeReleasedAt;
 
+    @Comment("보증금 반환을 요청한 시각. 요청했다는 뜻이지 반영됐다는 뜻이 아니다")
+    @Column(name = "deposit_release_requested_at")
+    private Timestamp depositReleaseRequestedAt;
+
+    @Comment("보증금 반환이 카드사에 반영된 것을 확인한 시각")
+    @Column(name = "deposit_release_confirmed_at")
+    private Timestamp depositReleaseConfirmedAt;
+
     @Comment("보증금 반환 일시")
     @Column(name = "deposit_returned_at")
     private Timestamp depositReturnedAt;
@@ -160,6 +168,25 @@ public class Escrow {
     public void markDepositReturned(String transactionUniqueNo, Timestamp returnedAt) {
         this.depositReturnTxNo = transactionUniqueNo;
         this.depositReturnedAt = returnedAt;
+        this.depositReleaseRequestedAt = returnedAt;
+    }
+
+    /**
+     * 보증금 반환이 카드사에 반영된 것을 확인했다.
+     *
+     * <p>요청과 확정을 가르는 이유는, 부분취소가 매입 뒤에 도는 절차라 영업일이 걸리기
+     * 때문이다. 요청한 자리에서 완료로 적으면 반영되지 않았을 때 고객은 돈을 못 받았는데
+     * 우리 기록만 돌려준 것이 된다.
+     */
+    public void confirmDepositRelease(Timestamp confirmedAt) {
+        this.depositReleaseConfirmedAt = confirmedAt;
+    }
+
+    /**
+     * 반환을 요청했지만 아직 반영을 확인하지 못했는지.
+     */
+    public boolean isDepositReleasePending() {
+        return this.depositReleaseRequestedAt != null && this.depositReleaseConfirmedAt == null;
     }
 
     /**

--- a/backend/src/main/java/com/joying/escrow/repository/EscrowRepository.java
+++ b/backend/src/main/java/com/joying/escrow/repository/EscrowRepository.java
@@ -25,6 +25,11 @@ public interface EscrowRepository extends JpaRepository<Escrow, Long> {
     List<Escrow> findByStatus(Status status);
 
     /**
+     * 보증금 반환을 요청했지만 아직 반영을 확인하지 못한 건.
+     */
+    List<Escrow> findByDepositReleaseRequestedAtIsNotNullAndDepositReleaseConfirmedAtIsNull();
+
+    /**
      * 결제 ID로 Escrow 존재 여부 확인
      */
     boolean existsByPayment_PaymentId(Long paymentId);

--- a/backend/src/main/java/com/joying/escrow/service/DepositReleaseConfirmationService.java
+++ b/backend/src/main/java/com/joying/escrow/service/DepositReleaseConfirmationService.java
@@ -1,0 +1,84 @@
+package com.joying.escrow.service;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joying.escrow.domain.Escrow;
+import com.joying.escrow.repository.EscrowRepository;
+import com.joying.payment.port.DepositHoldPort;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 보증금 반환을 요청한 뒤 실제로 반영됐는지 확인한다.
+ *
+ * <p>부분취소는 매입 뒤에 도는 절차라 카드사에 반영되기까지 영업일이 걸린다. 요청이
+ * 받아들여진 것과 고객 카드에 반영된 것은 다르고, 그 사이에 실패할 수 있다.
+ *
+ * <p>확정 근거는 결제에 남아 있는 금액이다. 되돌린 만큼 줄어 있으면 반영된 것이다.
+ * 조회가 실패하면 아무것도 확정하지 않는다. 실패를 "반영되지 않았다"로 읽으면 안 된다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DepositReleaseConfirmationService {
+
+	private final EscrowRepository escrowRepository;
+	private final DepositHoldPort depositHoldPort;
+
+	@Scheduled(fixedDelayString = "${joying.escrow.release-confirmation.interval-ms:300000}")
+	@Transactional
+	public void confirmRequestedReleases() {
+		List<Escrow> pending =
+			escrowRepository.findByDepositReleaseRequestedAtIsNotNullAndDepositReleaseConfirmedAtIsNull();
+		if (pending.isEmpty()) {
+			return;
+		}
+
+		log.info("[보증금 반환 확인] 대상 {}건", pending.size());
+
+		int confirmed = 0;
+		for (Escrow escrow : pending) {
+			String paymentKey = escrow.getPayment() == null ? null : escrow.getPayment().getPaymentKey();
+			if (paymentKey == null) {
+				log.warn("[보증금 반환 확인] 결제 정보가 없다: escrowId={}", escrow.getHoldId());
+				continue;
+			}
+
+			Optional<Long> remaining = depositHoldPort.remainingAmount(paymentKey);
+			if (remaining.isEmpty()) {
+				// 모른다. 다음 주기에 다시 묻는다.
+				continue;
+			}
+
+			long expected = expectedRemainingAfterRelease(escrow);
+			if (remaining.get() <= expected) {
+				escrow.confirmDepositRelease(Timestamp.from(Instant.now()));
+				confirmed++;
+				log.info("[보증금 반환 확인됨] escrowId={}, 남은금액={}, 기대={}",
+					escrow.getHoldId(), remaining.get(), expected);
+			} else {
+				log.info("[보증금 반환 아직 미반영] escrowId={}, 남은금액={}, 기대={}",
+					escrow.getHoldId(), remaining.get(), expected);
+			}
+		}
+
+		log.info("[보증금 반환 확인] 확정 {}건, 미확인 {}건", confirmed, pending.size() - confirmed);
+	}
+
+	/**
+	 * 보증금이 다 빠지고 나면 결제에 남아 있어야 하는 금액.
+	 *
+	 * <p>대여료는 그대로 남고 보증금만 줄어든다.
+	 */
+	private long expectedRemainingAfterRelease(Escrow escrow) {
+		return escrow.getRentalFee() == null ? 0L : escrow.getRentalFee().longValue();
+	}
+}

--- a/backend/src/main/java/com/joying/escrow/service/SettlementReconciliationService.java
+++ b/backend/src/main/java/com/joying/escrow/service/SettlementReconciliationService.java
@@ -1,0 +1,108 @@
+package com.joying.escrow.service;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.joying.escrow.domain.Escrow;
+import com.joying.escrow.domain.Status;
+import com.joying.escrow.repository.EscrowRepository;
+import com.joying.wallet.domain.Wallet;
+import com.joying.wallet.service.WalletService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 매일 장부를 검산한다.
+ *
+ * <p>결제와 취소와 정산이 각각 돌지만 셋을 맞춰 보는 곳이 없었다. 어긋나도 알 방법이
+ * 없다는 뜻이다. 에러가 나지 않는 사고는 이렇게 조용히 쌓인다.
+ *
+ * <p>검산식은 하나다.
+ *
+ * <pre>
+ *   중개 지갑 잔액 == 아직 대여자에게 나가지 않은 대여료의 합
+ * </pre>
+ *
+ * <p>보증금은 이 식에 없다. 플랫폼 장부를 지나지 않기 때문이다. 보증금이 여기 나타나면
+ * 어딘가에서 다시 우리 장부로 들어오고 있다는 뜻이므로, 그것 자체가 잡아야 할 신호다.
+ *
+ * <p>원장을 더한 값도 함께 본다. 지갑 행의 잔액과 원장 합계가 어긋나면 원장이 맞다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SettlementReconciliationService {
+
+	private final EscrowRepository escrowRepository;
+	private final WalletService walletService;
+
+	@Scheduled(cron = "${joying.escrow.reconciliation.cron:0 10 4 * * *}", zone = "Asia/Seoul")
+	@Transactional(readOnly = true)
+	public ReconciliationResult reconcile() {
+		Wallet escrowWallet = walletService.getOrCreateEscrowWallet();
+		long walletBalance = escrowWallet.getBalance();
+		long ledgerBalance = walletService.balanceFromLedger(escrowWallet.getWalletId());
+
+		long unsettledRentalFee = unsettledRentalFeeTotal();
+
+		ReconciliationResult result =
+			new ReconciliationResult(walletBalance, ledgerBalance, unsettledRentalFee);
+
+		if (result.isBalanced()) {
+			log.info("[대사] 맞음. 지갑={}, 원장={}, 미정산 대여료={}",
+				walletBalance, ledgerBalance, unsettledRentalFee);
+		} else {
+			// 조용히 넘기지 않는다. 하루 단위로 벌어지면 원인을 되짚기 어려워진다.
+			log.error("[대사 불일치] 지갑={}, 원장={}, 미정산 대여료={}, 지갑-원장={}, 지갑-미정산={}",
+				walletBalance, ledgerBalance, unsettledRentalFee,
+				result.walletMinusLedger(), result.walletMinusUnsettled());
+		}
+		return result;
+	}
+
+	/**
+	 * 적립은 됐지만 아직 대여자에게 나가지 않은 대여료의 합.
+	 */
+	private long unsettledRentalFeeTotal() {
+		List<Escrow> held = escrowRepository.findByStatus(Status.HELD);
+		List<Escrow> rentalStarted = escrowRepository.findByStatus(Status.RENTAL_STARTED);
+		List<Escrow> returnStarted = escrowRepository.findByStatus(Status.RETURN_STARTED);
+
+		return sumRentalFeeNotYetSent(held)
+			+ sumRentalFeeNotYetSent(rentalStarted)
+			+ sumRentalFeeNotYetSent(returnStarted);
+	}
+
+	private long sumRentalFeeNotYetSent(List<Escrow> escrows) {
+		return escrows.stream()
+			.filter(e -> !e.isRentalFeeSent())
+			.mapToLong(e -> e.getRentalFee() == null ? 0L : e.getRentalFee().longValue())
+			.sum();
+	}
+
+	/**
+	 * 검산 결과.
+	 *
+	 * @param walletBalance     지갑 행이 들고 있는 잔액
+	 * @param ledgerBalance     원장을 더해 나온 잔액
+	 * @param unsettledRentalFee 아직 나가지 않은 대여료의 합
+	 */
+	public record ReconciliationResult(long walletBalance, long ledgerBalance, long unsettledRentalFee) {
+
+		public long walletMinusLedger() {
+			return walletBalance - ledgerBalance;
+		}
+
+		public long walletMinusUnsettled() {
+			return walletBalance - unsettledRentalFee;
+		}
+
+		public boolean isBalanced() {
+			return walletMinusLedger() == 0 && walletMinusUnsettled() == 0;
+		}
+	}
+}

--- a/backend/src/main/java/com/joying/payment/adapter/deposit/FullCaptureDepositHoldAdapter.java
+++ b/backend/src/main/java/com/joying/payment/adapter/deposit/FullCaptureDepositHoldAdapter.java
@@ -96,6 +96,21 @@ public class FullCaptureDepositHoldAdapter implements DepositHoldPort {
 	}
 
 	@Override
+	public java.util.Optional<Long> remainingAmount(String paymentKey) {
+		try {
+			var payment = tossClient.getPaymentByPaymentKey(paymentKey);
+			if (payment == null || payment.getBalanceAmount() == null) {
+				return java.util.Optional.empty();
+			}
+			return java.util.Optional.of(payment.getBalanceAmount());
+		} catch (Exception e) {
+			// 조회가 실패한 것을 "반영되지 않았다"로 읽으면 안 된다. 모른다고 답한다.
+			log.warn("[보증금] 남은 금액 조회 실패: paymentKey={}, error={}", paymentKey, e.getMessage());
+			return java.util.Optional.empty();
+		}
+	}
+
+	@Override
 	public String name() {
 		return "full-capture";
 	}

--- a/backend/src/main/java/com/joying/payment/adapter/toss/TossPaymentsClientImpl.java
+++ b/backend/src/main/java/com/joying/payment/adapter/toss/TossPaymentsClientImpl.java
@@ -212,6 +212,44 @@ public class TossPaymentsClientImpl implements TossPaymentsClient {
         }
     }
 
+    @Override
+    public TossConfirmResponse getPaymentByPaymentKey(String paymentKey) {
+        log.info("[Toss API] 결제 조회 요청: paymentKey={}", paymentKey);
+
+        try {
+            TossConfirmResponse response = tossWebClient.get()
+                    .uri("/v1/payments/{paymentKey}", paymentKey)
+                    .header(HttpHeaders.AUTHORIZATION, "Basic " + basic(secretKey + ":"))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                            clientResponse.bodyToMono(String.class)
+                                    .flatMap(errorBody -> {
+                                        log.error("[Toss API] 결제 조회 4xx 에러: {}", errorBody);
+                                        return Mono.error(new TossPaymentException("CLIENT_ERROR", errorBody));
+                                    })
+                    )
+                    .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                            clientResponse.bodyToMono(String.class)
+                                    .flatMap(errorBody -> {
+                                        log.error("[Toss API] 결제 조회 5xx 에러: {}", errorBody);
+                                        return Mono.error(new TossPaymentException("SERVER_ERROR", errorBody));
+                                    })
+                    )
+                    .bodyToMono(TossConfirmResponse.class)
+                    .block();
+
+            log.info("[Toss API] 결제 조회 성공: paymentKey={}, status={}", paymentKey, response.getStatus());
+            return response;
+
+        } catch (WebClientResponseException e) {
+            log.error("[Toss API] 결제 조회 실패: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new TossPaymentException("TOSS_API_ERROR", e.getResponseBodyAsString(), e);
+        } catch (Exception e) {
+            log.error("[Toss API] 결제 조회 예외: {}", e.getMessage(), e);
+            throw new TossPaymentException("TOSS_API_ERROR", e.getMessage(), e);
+        }
+    }
+
     /**
      * Base64 인코딩 (Basic Auth)
      */

--- a/backend/src/main/java/com/joying/payment/dto/response/TossConfirmResponse.java
+++ b/backend/src/main/java/com/joying/payment/dto/response/TossConfirmResponse.java
@@ -10,4 +10,17 @@ public class TossConfirmResponse {
     private String method;
     private String approvedAt;
     private String receiptUrl;
+
+    /**
+     * 결제 총액.
+     */
+    private Long totalAmount;
+
+    /**
+     * 아직 취소되지 않고 남아 있는 금액.
+     *
+     * <p>부분취소가 카드사에 반영되면 이 값이 그만큼 줄어든다. 취소를 요청한 것과
+     * 실제로 반영된 것을 가르는 근거가 이 값이다.
+     */
+    private Long balanceAmount;
 }

--- a/backend/src/main/java/com/joying/payment/port/DepositHoldPort.java
+++ b/backend/src/main/java/com/joying/payment/port/DepositHoldPort.java
@@ -39,6 +39,19 @@ public interface DepositHoldPort {
 						  String reference, String reason);
 
 	/**
+	 * 이 결제에서 아직 취소되지 않고 남아 있는 금액.
+	 *
+	 * <p>되돌려 달라고 요청한 것과 카드사에 실제로 반영된 것은 다르다. 부분취소는
+	 * 매입 뒤에 도는 절차라 영업일이 걸린다. 요청한 자리에서 완료로 적으면, 반영되지
+	 * 않았을 때 고객은 돈을 못 받았는데 우리 기록만 돌려준 것이 된다.
+	 *
+	 * <p>그래서 확정은 이 값으로 판단한다. 되돌린 만큼 줄어 있으면 반영된 것이다.
+	 *
+	 * @return 남은 금액. 알 수 없으면 비어 있음
+	 */
+	java.util.Optional<Long> remainingAmount(String paymentKey);
+
+	/**
 	 * 이 구현이 보증금을 어떻게 다루는지. 로그와 운영 화면에서 구분하는 데 쓴다.
 	 */
 	String name();

--- a/backend/src/main/java/com/joying/payment/port/TossPaymentsClient.java
+++ b/backend/src/main/java/com/joying/payment/port/TossPaymentsClient.java
@@ -25,4 +25,12 @@ public interface TossPaymentsClient {
      * @return 결제 정보
      */
     TossConfirmResponse getPaymentByOrderId(String orderId);
+
+    /**
+     * paymentKey로 결제를 조회한다.
+     *
+     * <p>취소가 실제로 반영됐는지 확인할 때 쓴다. 응답의 남은 금액이 되돌린 만큼
+     * 줄어 있으면 반영된 것이다.
+     */
+    TossConfirmResponse getPaymentByPaymentKey(String paymentKey);
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -184,6 +184,18 @@ web-push.private-key=${WEB_PUSH_PRIVATE_KEY:}
 #          다른 결제망을 붙일 때 그 모양을 그대로 쓴다
 joying.money.transfer=${JOYING_MONEY_TRANSFER:wallet}
 
+# 대여 기간 상한. 보증금을 붙잡아 둘 수 있는 기간 안에서만 받는다
+joying.rental.max-period-days=${RENTAL_MAX_PERIOD_DAYS:21}
+
+# 보증금 반환을 요청한 뒤 카드사에 반영됐는지 다시 확인하는 주기
+joying.escrow.release-confirmation.interval-ms=${ESCROW_RELEASE_CONFIRMATION_INTERVAL_MS:300000}
+
+# 매일 장부를 검산하는 시각
+joying.escrow.reconciliation.cron=${ESCROW_RECONCILIATION_CRON:0 10 4 * * *}
+
+# 미확정 적립을 다시 물어 확정하는 주기 (외부 금융망 구현일 때만 돈다)
+joying.escrow.deposit-recovery.interval-ms=${ESCROW_DEPOSIT_RECOVERY_INTERVAL_MS:60000}
+
 # 아래 금융망 설정은 joying.money.transfer=ssafy 일 때만 쓰인다
 ssafy.finance.base-url=${SSAFY_FINANCE_BASE_URL:https://finopenapi.ssafy.io}
 ssafy.finance.api-key=${SSAFY_FINANCE_API_KEY:}

--- a/backend/src/test/java/com/joying/escrow/ReconciliationTest.java
+++ b/backend/src/test/java/com/joying/escrow/ReconciliationTest.java
@@ -1,0 +1,67 @@
+package com.joying.escrow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.joying.escrow.service.SettlementReconciliationService.ReconciliationResult;
+
+/**
+ * 대사가 무엇을 잡아내야 하는지 고정한다.
+ *
+ * <p>에러가 나지 않는 사고는 조용히 쌓인다. 결제와 취소와 정산이 각각 도는데 셋을
+ * 맞춰 보는 곳이 없으면, 어긋나도 알 방법이 없다.
+ */
+class ReconciliationTest {
+
+	@Test
+	@DisplayName("지갑 잔액과 원장 합계와 미정산 대여료가 모두 같으면 맞은 것이다")
+	void balancedWhenAllThreeAgree() {
+		ReconciliationResult result = new ReconciliationResult(50_000L, 50_000L, 50_000L);
+
+		assertThat(result.isBalanced()).isTrue();
+		assertThat(result.walletMinusLedger()).isZero();
+		assertThat(result.walletMinusUnsettled()).isZero();
+	}
+
+	@Test
+	@DisplayName("지갑 잔액이 원장보다 크면 원장에 안 적힌 돈이 들어온 것이다")
+	void detectsMoneyMissingFromLedger() {
+		ReconciliationResult result = new ReconciliationResult(60_000L, 50_000L, 60_000L);
+
+		assertThat(result.isBalanced()).isFalse();
+		assertThat(result.walletMinusLedger()).isEqualTo(10_000L);
+	}
+
+	@Test
+	@DisplayName("지갑 잔액이 미정산 대여료보다 크면 나가야 할 돈이 안 나간 것이다")
+	void detectsUnsentSettlement() {
+		ReconciliationResult result = new ReconciliationResult(80_000L, 80_000L, 50_000L);
+
+		assertThat(result.isBalanced()).isFalse();
+		assertThat(result.walletMinusUnsettled()).isEqualTo(30_000L);
+	}
+
+	@Test
+	@DisplayName("지갑 잔액이 미정산 대여료보다 작으면 없는 돈을 보낸 것이다")
+	void detectsOverpayment() {
+		ReconciliationResult result = new ReconciliationResult(20_000L, 20_000L, 50_000L);
+
+		assertThat(result.isBalanced()).isFalse();
+		assertThat(result.walletMinusUnsettled()).isEqualTo(-30_000L);
+	}
+
+	@Test
+	@DisplayName("보증금은 이 식에 나타나지 않는다. 나타나면 다시 우리 장부로 들어온 것이다")
+	void depositDoesNotAppearInTheEquation() {
+		// 대여료 50,000원만 적립된 상태. 보증금 300,000원은 결제에 남아 있다.
+		ReconciliationResult result = new ReconciliationResult(50_000L, 50_000L, 50_000L);
+		assertThat(result.isBalanced()).isTrue();
+
+		// 보증금이 지갑으로 들어오면 지갑만 커져 바로 드러난다.
+		ReconciliationResult withDeposit = new ReconciliationResult(350_000L, 350_000L, 50_000L);
+		assertThat(withDeposit.isBalanced()).isFalse();
+		assertThat(withDeposit.walletMinusUnsettled()).isEqualTo(300_000L);
+	}
+}


### PR DESCRIPTION
Closes #23
Base: #22 (refactor/deposit-off-platform-ledger)

## 요청은 완료가 아니다

보증금 반환은 **요청이 받아들여진 것**을 완료로 적고 있었다. 부분취소는 매입 뒤에 도는 절차라 카드사에 반영되기까지 영업일이 걸린다.

요청 즉시 완료로 적으면 반영되지 않았을 때 **고객은 돈을 못 받았는데 우리 기록은 돌려줬다고** 되어 있다. #14에서 다룬 미확정과 같은 자리다.

| | 전 | 후 |
|---|---|---|
| 반환 기록 | 완료 하나 | 요청 시각 · 확정 시각 |
| 확정 | 없음 | 5분마다 카드사에 다시 물음 |
| 확정 근거 | — | 결제에 남은 금액이 되돌린 만큼 줄었는가 |
| 조회 실패 시 | — | 아무것도 확정하지 않음 |

마지막 줄이 중요하다. 조회 실패를 `반영되지 않았다`로 읽으면 **이미 돌려준 돈을 다시 돌려준다.**

## 대사

결제와 취소와 정산이 각각 돌지만 셋을 맞춰 보는 곳이 없었다.

```
중개 지갑 잔액 == 아직 대여자에게 나가지 않은 대여료의 합
```

**보증금은 이 식에 없다.** 플랫폼 장부를 지나지 않기 때문이다. 보증금이 여기 나타나면 어딘가에서 다시 우리 장부로 들어오고 있다는 뜻이므로, 그것 자체가 잡아야 할 신호다. 테스트로 그 경우를 고정해 뒀다.

원장을 더한 값도 함께 본다. 지갑 행의 잔액과 원장 합계가 어긋나면 원장이 맞다.

## 확인

클린 빌드 통과. 전체 테스트 41개 통과 (대사 5, 보증금 7, 지갑 7, 정산 4, 재조회 4, 금융망 판정 9, 브로드캐스트 4, 브로커 2, Mongo 인덱스 2, 컨텍스트 1).