### PR TITLE
test: 채팅 모듈의 현재 동작을 테스트로 고정한다

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -94,6 +94,8 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers") // Testcontainers BOM 관리
     testImplementation("org.testcontainers:mongodb")
     testImplementation("org.testcontainers:mysql")
+    // Kotlin에서 Mockito를 쓸 때 널 안전성 때문에 그대로는 불편하다.
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     // Redis 전용 Testcontainer는 없으므로 GenericContainer 사용
 
     implementation("software.amazon.awssdk:s3:2.28.23")

--- a/backend/src/test/kotlin/com/joying/chat/service/ChatRoomPermissionCacheTest.kt
+++ b/backend/src/test/kotlin/com/joying/chat/service/ChatRoomPermissionCacheTest.kt
@@ -1,0 +1,133 @@
+package com.joying.chat.service
+
+import com.joying.chat.domain.ChatRoom
+import com.joying.chat.repository.ChatRoomRepository
+import com.joying.member.domain.Member
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+
+/**
+ * 채팅방 권한 캐시의 현재 동작을 고정한다.
+ *
+ * 실사에서 결함이 나온 자리라 특히 조심해서 박아 둔다. 캐시가 무엇을 근거로
+ * 판정하는지, 무엇을 보지 않는지를 테스트가 그대로 드러내게 썼다.
+ */
+class ChatRoomPermissionCacheTest {
+
+    private lateinit var redis: RedisTemplate<String, String>
+    private lateinit var valueOps: ValueOperations<String, String>
+    private lateinit var chatRoomRepository: ChatRoomRepository
+    private lateinit var cache: ChatRoomPermissionCache
+
+    private val roomId = 1L
+    private val buyerId = 100L
+    private val sellerId = 200L
+    private val strangerId = 999L
+
+    @BeforeEach
+    fun setUp() {
+        redis = mock()
+        valueOps = mock()
+        chatRoomRepository = mock()
+        whenever(redis.opsForValue()).thenReturn(valueOps)
+        cache = ChatRoomPermissionCache(redis, chatRoomRepository)
+    }
+
+    private fun key(memberId: Long) = "chatroom:permission:$roomId:$memberId"
+
+    private fun roomWith(buyer: Long, seller: Long): ChatRoom {
+        val buyerMember = mock<Member>()
+        val sellerMember = mock<Member>()
+        whenever(buyerMember.getMemberId()).thenReturn(buyer)
+        whenever(sellerMember.getMemberId()).thenReturn(seller)
+
+        val room = mock<ChatRoom>()
+        whenever(room.buyer).thenReturn(buyerMember)
+        whenever(room.seller).thenReturn(sellerMember)
+        return room
+    }
+
+    @Test
+    @DisplayName("캐시에 ALLOWED가 있으면 저장소를 보지 않는다")
+    fun cacheHitSkipsDatabase() = runBlocking<Unit> {
+        whenever(valueOps.get(key(buyerId))).thenReturn("ALLOWED")
+
+        assertThat(cache.hasPermission(roomId, buyerId)).isTrue()
+        verify(chatRoomRepository, never()).findById(any())
+    }
+
+    @Test
+    @DisplayName("캐시에 DENIED가 있으면 거절이다")
+    fun cachedDenialIsHonored() = runBlocking<Unit> {
+        whenever(valueOps.get(key(strangerId))).thenReturn("DENIED")
+
+        assertThat(cache.hasPermission(roomId, strangerId)).isFalse()
+        verify(chatRoomRepository, never()).findById(any())
+    }
+
+    @Test
+    @DisplayName("캐시가 비었으면 저장소를 보고 결과를 캐싱한다")
+    fun cacheMissChecksDatabaseAndCaches() = runBlocking<Unit> {
+        val room = roomWith(buyerId, sellerId)
+        whenever(valueOps.get(key(buyerId))).thenReturn(null)
+        whenever(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(room))
+
+        assertThat(cache.hasPermission(roomId, buyerId)).isTrue()
+        verify(valueOps).set(eq(key(buyerId)), eq("ALLOWED"), any(), eq(TimeUnit.HOURS))
+    }
+
+    @Test
+    @DisplayName("방에 없는 사람은 거절이고 그것도 캐싱한다")
+    fun strangerIsDeniedAndCached() = runBlocking<Unit> {
+        val room = roomWith(buyerId, sellerId)
+        whenever(valueOps.get(key(strangerId))).thenReturn(null)
+        whenever(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(room))
+
+        assertThat(cache.hasPermission(roomId, strangerId)).isFalse()
+        verify(valueOps).set(eq(key(strangerId)), eq("DENIED"), any(), eq(TimeUnit.HOURS))
+    }
+
+    @Test
+    @DisplayName("방이 없으면 거절이다")
+    fun missingRoomIsDenied() = runBlocking<Unit> {
+        whenever(valueOps.get(key(buyerId))).thenReturn(null)
+        whenever(chatRoomRepository.findById(roomId)).thenReturn(Optional.empty())
+
+        assertThat(cache.hasPermission(roomId, buyerId)).isFalse()
+    }
+
+    @Test
+    @DisplayName("알려진 결함: 판정 근거가 buyer/seller뿐이라 방을 나갔는지는 보지 않는다")
+    fun knownDefect_ignoresWhetherMemberLeft() = runBlocking<Unit> {
+        // 판정은 chatRoom의 buyer/seller와 같은 사람인가만 본다. ChatRoomMember의
+        // isLeft도, 방의 status도 보지 않는다.
+        //
+        // 그래서 나가기에서 캐시를 지워도 다음 조회가 같은 근거로 다시 ALLOWED를
+        // 계산해 캐싱한다. 무효화가 결과를 바꿀 수 없다는 뜻이다.
+        //
+        // 나간 사람을 실제로 막는 것은 이 캐시가 아니라 메시지 전송 경로의 별도
+        // 조회다. 조회 경로에는 그 검사가 없어 히스토리가 열려 있다.
+        //
+        // 이관 중에 고치지 않는다. 지금 동작을 박아 두고 이관이 끝난 뒤 뒤집는다.
+        val room = roomWith(buyerId, sellerId)
+        whenever(valueOps.get(key(buyerId))).thenReturn(null)
+        whenever(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(room))
+
+        assertThat(cache.hasPermission(roomId, buyerId))
+            .`as`("나갔더라도 buyer이면 통과한다")
+            .isTrue()
+    }
+}

--- a/backend/src/test/kotlin/com/joying/chat/service/UnreadCountServiceTest.kt
+++ b/backend/src/test/kotlin/com/joying/chat/service/UnreadCountServiceTest.kt
@@ -1,0 +1,140 @@
+package com.joying.chat.service
+
+import com.joying.chat.domain.ChatRoomMember
+import com.joying.chat.repository.ChatMessageRepository
+import com.joying.chat.repository.ChatRoomMemberRepository
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ValueOperations
+import java.time.Instant
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+
+/**
+ * 안읽음 개수의 현재 동작을 고정한다.
+ *
+ * 여기서 검증하는 것은 "올바른 동작"이 아니라 "지금 동작"이다. 실사에서 나온 결함이
+ * 이미 몇 개 있지만 그것을 여기서 고치지 않는다. 고치면 무엇이 원래 동작이었는지
+ * 알 수 없게 되고, 이관이 끝난 뒤 무엇이 깨졌는지 가릴 수도 없어진다.
+ *
+ * 알고 있는 결함은 테스트 이름과 주석에 그대로 적어 둔다.
+ */
+class UnreadCountServiceTest {
+
+    private lateinit var redis: RedisTemplate<String, String>
+    private lateinit var valueOps: ValueOperations<String, String>
+    private lateinit var messageRepository: ChatMessageRepository
+    private lateinit var memberRepository: ChatRoomMemberRepository
+    private lateinit var service: UnreadCountService
+
+    private val roomId = 1L
+    private val memberId = 100L
+    private val key = "unread:1:100"
+
+    @BeforeEach
+    fun setUp() {
+        redis = mock()
+        valueOps = mock()
+        messageRepository = mock()
+        memberRepository = mock()
+        whenever(redis.opsForValue()).thenReturn(valueOps)
+        service = UnreadCountService(redis, messageRepository, memberRepository)
+    }
+
+    @Test
+    @DisplayName("증가하면 값을 올리고 만료를 다시 건다")
+    fun incrementRaisesAndRefreshesTtl() {
+        service.increment(roomId, memberId)
+
+        verify(valueOps).increment(key)
+        verify(redis).expire(eq(key), any(), eq(TimeUnit.DAYS))
+    }
+
+    @Test
+    @DisplayName("Redis가 죽어도 증가는 예외를 던지지 않는다. 메시지 저장을 되돌리지 않기 위해서다")
+    fun incrementSwallowsRedisFailure() {
+        whenever(valueOps.increment(key)).doThrow(RuntimeException("Redis 연결 실패"))
+
+        service.increment(roomId, memberId)
+        // 예외가 올라오지 않는다
+    }
+
+    @Test
+    @DisplayName("초기화하면 키를 지운다")
+    fun resetDeletesKey() {
+        service.reset(roomId, memberId)
+
+        verify(redis).delete(key)
+    }
+
+    @Test
+    @DisplayName("캐시에 값이 있으면 그 값을 그대로 돌려주고 저장소를 보지 않는다")
+    fun returnsCachedValueWithoutTouchingStores() = runBlocking<Unit> {
+        whenever(valueOps.get(key)).thenReturn("7")
+
+        val count = service.get(roomId, memberId)
+
+        assertThat(count).isEqualTo(7L)
+        verify(memberRepository, never()).findByChatRoomIdAndMemberId(any(), any())
+    }
+
+    @Test
+    @DisplayName("캐시가 비었고 방 멤버가 아니면 0이다")
+    fun returnsZeroWhenNotAMember() = runBlocking<Unit> {
+        whenever(valueOps.get(key)).thenReturn(null)
+        whenever(memberRepository.findByChatRoomIdAndMemberId(roomId, memberId))
+            .thenReturn(Optional.empty())
+
+        assertThat(service.get(roomId, memberId)).isZero()
+    }
+
+    @Test
+    @DisplayName("캐시가 비었으면 저장소에서 세되 본인이 보낸 것은 빼고 센다")
+    fun countsOnlyMessagesFromOthers() = runBlocking<Unit> {
+        val lastReadAt = Instant.parse("2026-01-01T00:00:00Z")
+        val member = mock<ChatRoomMember>()
+        whenever(member.lastReadAt).thenReturn(lastReadAt)
+
+        whenever(valueOps.get(key)).thenReturn(null)
+        whenever(memberRepository.findByChatRoomIdAndMemberId(roomId, memberId))
+            .thenReturn(Optional.of(member))
+        whenever(
+            messageRepository.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(
+                roomId, lastReadAt, memberId
+            )
+        ).thenReturn(3L)
+
+        assertThat(service.get(roomId, memberId)).isEqualTo(3L)
+    }
+
+    @Test
+    @DisplayName("알려진 결함: 방을 한 번도 안 열었으면 쌓인 메시지가 있어도 0으로 본다")
+    fun knownDefect_zeroWhenNeverOpened() = runBlocking<Unit> {
+        // lastReadAt이 null이면 저장소를 보지 않고 0을 돌려준다. 방을 한 번도 안 연
+        // 사람은 메시지가 아무리 쌓여도 배지가 0으로 보인다.
+        //
+        // 이관 중에 고치지 않는다. 지금 동작을 그대로 박아 두고, 이관이 끝난 뒤에
+        // 이 테스트를 뒤집으면서 고친다.
+        val member = mock<ChatRoomMember>()
+        whenever(member.lastReadAt).thenReturn(null)
+
+        whenever(valueOps.get(key)).thenReturn(null)
+        whenever(memberRepository.findByChatRoomIdAndMemberId(roomId, memberId))
+            .thenReturn(Optional.of(member))
+
+        assertThat(service.get(roomId, memberId)).isZero()
+        verify(messageRepository, never())
+            .countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(any(), any(), any())
+    }
+}


### PR DESCRIPTION
Closes #25
Base: #24

chat 패키지 45개 파일 5,600여 줄에 테스트가 0건이었다. Kotlin을 Java로 옮기기 전에 회귀를 잡을 수단이 필요하다.

## 검증이 아니라 고정이다

여기서 하는 것은 **올바른 동작을 검증하는 게 아니라 지금 동작을 박아 두는 것**이다. 실사에서 나온 결함이 이미 여럿 있지만 고치지 않았다. 고치면 무엇이 원래 동작이었는지 알 수 없게 되고, 이관 뒤에 무엇이 깨졌는지도 못 가린다.

알고 있는 결함은 테스트 이름에 `알려진 결함`으로 적어 뒀다.

| 결함 | 어디 |
|---|---|
| 방을 한 번도 안 열면 안읽음이 0으로 보인다 | `UnreadCountService` |
| 권한 판정이 나갔는지를 안 봐서 무효화가 무의미하다 | `ChatRoomPermissionCache` |

이관이 끝나면 이 테스트들을 뒤집으면서 고친다.

## 고정한 것

- 안읽음 개수 7개
- 권한 캐시 6개

## 테스트를 Kotlin으로 쓴 이유

지금 API에 `suspend` 함수가 있어 Java에서 그대로 부를 수 없다. #26에서 코루틴을 걷어내고 #27에서 Java로 옮길 때 테스트도 같이 옮긴다.

`runBlocking`은 반환 타입을 `Unit`으로 못박아야 한다. 안 그러면 **JUnit이 테스트로 인식하지 않고 조용히 건너뛴다.** 실제로 처음에 네 개가 그렇게 빠졌다.

## 확인

클린 빌드 통과. 전체 테스트 54개 통과.