### PR TITLE
refactor: 이득 없는 코루틴을 걷어낸다

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -45,9 +45,6 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
 
     // Kotlin Coroutines (비동기 처리 - 채팅 기능용)
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.9.0") // Spring MVC suspend fun 지원
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 
 	// WebClient (외부 API 호출용 - Toss Payments 등)
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/backend/src/main/kotlin/com/joying/chat/config/ChatQueryExecutorConfig.kt
+++ b/backend/src/main/kotlin/com/joying/chat/config/ChatQueryExecutorConfig.kt
@@ -1,0 +1,36 @@
+package com.joying.chat.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+/**
+ * 서로 의존하지 않는 조회를 동시에 날릴 때 쓰는 풀.
+ *
+ * 방 목록을 열면 방마다 안읽음을 세야 한다. 순차로 하면 방 수만큼 지연이 더해지고,
+ * 동시에 하면 제일 느린 것만큼만 걸린다.
+ *
+ * 예전에는 이 자리를 코루틴이 맡았다. 그런데 밑에 있는 저장소가 전부 블로킹이라
+ * 코루틴이 사 주는 것이 없었고, 오히려 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더
+ * 쓰고 있었다. 병렬로 날리는 것만 남기고 나머지는 걷어냈다.
+ *
+ * 풀 크기를 묶어 둔 이유는 밑이 블로킹이기 때문이다. 무제한으로 늘리면 방이 많은
+ * 사용자 하나가 데이터베이스 커넥션을 전부 가져갈 수 있다.
+ */
+@Configuration
+class ChatQueryExecutorConfig {
+
+    @Bean(name = ["chatQueryExecutor"], destroyMethod = "shutdown")
+    fun chatQueryExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 4
+        executor.maxPoolSize = 16
+        executor.queueCapacity = 200
+        executor.setThreadNamePrefix("chat-query-")
+        // 큐가 차면 부른 스레드가 직접 처리한다. 조회를 버리면 안읽음이 0으로 보인다.
+        executor.setRejectedExecutionHandler(java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy())
+        executor.initialize()
+        return executor
+    }
+}

--- a/backend/src/main/kotlin/com/joying/chat/config/MongoConfig.kt
+++ b/backend/src/main/kotlin/com/joying/chat/config/MongoConfig.kt
@@ -17,7 +17,7 @@ import org.springframework.data.domain.Sort
  * MongoDB Blocking 설정
  *
  * 채팅 메시지 저장용 NoSQL 설정
- * - Blocking MongoDB + Coroutine withContext(Dispatchers.IO) 패턴 (현업 표준)
+ * - 블로킹 MongoDB. 서비스에서 그대로 부른다
  * - MongoDB Auditing 활성화 (@CreatedDate 자동 설정)
  * - _class 필드 제거 (불필요한 메타데이터 저장 방지)
  */

--- a/backend/src/main/kotlin/com/joying/chat/controller/ChatRoomController.kt
+++ b/backend/src/main/kotlin/com/joying/chat/controller/ChatRoomController.kt
@@ -9,7 +9,6 @@ import com.joying.chat.service.ChatService
 import com.joying.common.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.Authentication
@@ -80,7 +79,6 @@ class ChatRoomController(
         val includes = include?.split(",")?.map { it.trim() } ?: emptyList()
         val includeMember = includes.contains("member")
 
-        // Service에서 runBlocking 처리 (HTTP Thread에서 완료)
         val chatRooms = chatRoomService.getMyChatRooms(memberId, includeMember)
 
         logger.info("채팅방 목록 조회 완료: memberId={}, 채팅방 개수={}", memberId, chatRooms.size)
@@ -121,7 +119,6 @@ class ChatRoomController(
         val includes = include?.split(",")?.map { it.trim() } ?: emptyList()
         val includeMember = includes.contains("member")
 
-        // Service에서 runBlocking 처리 (HTTP Thread에서 완료)
         val chatRoom = chatRoomService.getChatRoomDetail(chatRoomId, memberId, includeMember)
 
         return ApiResponse.ok("채팅방 상세 조회 완료", chatRoom)

--- a/backend/src/main/kotlin/com/joying/chat/repository/ChatMessageRepository.kt
+++ b/backend/src/main/kotlin/com/joying/chat/repository/ChatMessageRepository.kt
@@ -11,7 +11,7 @@ import java.time.Instant
  * 채팅 메시지 Repository (MongoDB Blocking)
  *
  * 현업 표준 패턴: 단순하고 안정적인 blocking I/O
- * - Coroutine은 Service 레이어에서 withContext(Dispatchers.IO) 사용
+ * - 블로킹 저장소다. 서비스에서 그대로 부른다
  */
 @Repository
 interface ChatMessageRepository : MongoRepository<ChatMessage, String> {

--- a/backend/src/main/kotlin/com/joying/chat/repository/ChatRoomRepository.kt
+++ b/backend/src/main/kotlin/com/joying/chat/repository/ChatRoomRepository.kt
@@ -88,7 +88,7 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, Long> {
      * Product, Buyer, Seller, ProfileImage(File)를 한 번에 조회
      *
      * 푸시 알림 전송 시 LazyInitializationException 방지용
-     * - withContext(Dispatchers.IO)에서 별도 스레드로 전환되면 Hibernate Session이 끊김
+     * - 트랜잭션 밖에서 지연 로딩을 만지면 Hibernate Session이 끊겨 있다
      * - Member.profileImage (File 엔티티)까지 미리 로드하여 세션 없이도 접근 가능
      */
     @Query("""

--- a/backend/src/main/kotlin/com/joying/chat/service/ChatMessageService.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/ChatMessageService.kt
@@ -6,8 +6,6 @@ import com.joying.chat.repository.ChatMessageRepository
 import com.joying.chat.repository.ChatRoomRepository
 import com.joying.common.exception.BusinessException
 import com.joying.common.exception.ErrorCode
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -17,7 +15,7 @@ import java.time.Instant
 /**
  * 채팅 메시지 Service
  *
- * Blocking Repository + Coroutine withContext 패턴 (현업 표준)
+ * 저장소가 전부 블로킹이라 그대로 부른다. 서로 의존하지 않는 조회만 동시에 날린다.
  */
 @Service
 class ChatMessageService(
@@ -52,8 +50,8 @@ class ChatMessageService(
      * @param size 페이지 크기
      * @return 메시지 목록 (최신순)
      */
-    suspend fun getMessages(chatRoomId: Long, page: Int, size: Int): List<ChatMessageResponse> =
-        withContext(Dispatchers.IO) {
+    fun getMessages(chatRoomId: Long, page: Int, size: Int): List<ChatMessageResponse> =
+        run {
             val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
 
             chatMessageRepository
@@ -67,14 +65,14 @@ class ChatMessageService(
         }
 
     /**
-     * 커서 기반 페이징으로 메시지 조회 (통합) - runBlocking 방식
+     * 커서 기반 페이징으로 메시지 조회 (통합)
      *
      * - before 파라미터: 과거 메시지 조회 (무한 스크롤)
      * - after 파라미터: 놓친 메시지 조회 (재연결 시)
      *
-     * runBlocking 사용 이유:
-     * - Spring MVC 환경에서 SecurityContext 유지
-     * - HTTP Thread에서 응답 반환 보장
+     * 예전에는 이 자리를 코루틴이 맡았다. 밑에 있는 저장소가 전부 블로킹이라
+     * 코루틴이 사 주는 것이 없었고, 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더
+     * 쓰고 있었다. 지금은 그냥 부른다.
      *
      * @param chatRoomId 채팅방 ID
      * @param before 이 시간 이전의 메시지 조회 (과거 방향, 최신순 정렬)
@@ -89,7 +87,7 @@ class ChatMessageService(
         after: Instant? = null,
         size: Int,
         memberId: Long
-    ): List<ChatMessageResponse> = kotlinx.coroutines.runBlocking {
+    ): List<ChatMessageResponse> = run {
         // 권한 확인
         validateChatRoomAccess(chatRoomId, memberId)
 
@@ -136,11 +134,11 @@ class ChatMessageService(
     }
 
     /**
-     * 채팅방에서 메시지 검색 - runBlocking 방식
+     * 채팅방에서 메시지 검색
      *
-     * runBlocking 사용 이유:
-     * - Spring MVC 환경에서 SecurityContext 유지
-     * - HTTP Thread에서 응답 반환 보장
+     * 예전에는 이 자리를 코루틴이 맡았다. 밑에 있는 저장소가 전부 블로킹이라
+     * 코루틴이 사 주는 것이 없었고, 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더
+     * 쓰고 있었다. 지금은 그냥 부른다.
      *
      * @param chatRoomId 채팅방 ID
      * @param keyword 검색어
@@ -155,7 +153,7 @@ class ChatMessageService(
         page: Int,
         size: Int,
         memberId: Long
-    ): List<ChatMessageResponse> = kotlinx.coroutines.runBlocking {
+    ): List<ChatMessageResponse> = run {
         // 권한 확인
         validateChatRoomAccess(chatRoomId, memberId)
         val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
@@ -181,10 +179,10 @@ class ChatMessageService(
      * @param lastReadAt 마지막으로 읽은 시간
      * @return 안읽은 메시지 개수
      */
-    suspend fun getUnreadCount(chatRoomId: Long, lastReadAt: Instant?): Long =
-        withContext(Dispatchers.IO) {
+    fun getUnreadCount(chatRoomId: Long, lastReadAt: Instant?): Long =
+        run {
             if (lastReadAt == null) {
-                return@withContext 0L
+                return 0L
             }
 
             chatMessageRepository.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfter(chatRoomId, lastReadAt)
@@ -202,12 +200,12 @@ class ChatMessageService(
      * @param memberId 요청한 회원 ID (권한 확인용)
      * @return 놓친 메시지 목록 (오래된 순)
      */
-    suspend fun getMessagesAfter(
+    fun getMessagesAfter(
         chatRoomId: Long,
         after: Instant,
         limit: Int = 100,
         memberId: Long
-    ): List<ChatMessageResponse> = withContext(Dispatchers.IO) {
+    ): List<ChatMessageResponse> = run {
         // 권한 확인
         validateChatRoomAccess(chatRoomId, memberId)
         val pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "createdAt"))
@@ -247,7 +245,7 @@ class ChatMessageService(
         before: Int = 20,
         after: Int = 20,
         memberId: Long
-    ): List<ChatMessageResponse> = kotlinx.coroutines.runBlocking {
+    ): List<ChatMessageResponse> = run {
         // 권한 확인
         validateChatRoomAccess(chatRoomId, memberId)
 
@@ -302,9 +300,9 @@ class ChatMessageService(
     /**
      * 메시지 삭제 (Soft Delete) - 현업 표준 버전
      *
-     * runBlocking 사용 이유:
-     * - Spring MVC 환경에서 SecurityContext 유지
-     * - HTTP Thread에서 응답 반환 보장
+     * 예전에는 이 자리를 코루틴이 맡았다. 밑에 있는 저장소가 전부 블로킹이라
+     * 코루틴이 사 주는 것이 없었고, 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더
+     * 쓰고 있었다. 지금은 그냥 부른다.
      *
      * 개선 사항:
      * - 삭제 후 Redis Pub/Sub 발행 (실시간 동기화)
@@ -316,7 +314,7 @@ class ChatMessageService(
      * @param memberId 요청한 회원 ID (권한 확인용)
      */
     fun deleteMessage(chatRoomId: Long, messageId: String, memberId: Long) =
-        kotlinx.coroutines.runBlocking {
+        run {
             try {
                 val message = chatMessageRepository.findById(messageId)
                     .orElseThrow { BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "메시지를 찾을 수 없습니다") }
@@ -386,9 +384,9 @@ class ChatMessageService(
     /**
      * 메시지 수정 - 현업 표준 버전
      *
-     * runBlocking 사용 이유:
-     * - Spring MVC 환경에서 SecurityContext 유지
-     * - HTTP Thread에서 응답 반환 보장
+     * 예전에는 이 자리를 코루틴이 맡았다. 밑에 있는 저장소가 전부 블로킹이라
+     * 코루틴이 사 주는 것이 없었고, 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더
+     * 쓰고 있었다. 지금은 그냥 부른다.
      *
      * 개선 사항:
      * - 첫 수정 시 원본 내용 저장 (originalContent)
@@ -409,7 +407,7 @@ class ChatMessageService(
         messageId: String,
         memberId: Long,
         newContent: String
-    ): ChatMessageResponse = kotlinx.coroutines.runBlocking {
+    ): ChatMessageResponse = run {
         try {
             // 공백 검증
             if (newContent.isBlank()) {

--- a/backend/src/main/kotlin/com/joying/chat/service/ChatRoomPermissionCache.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/ChatRoomPermissionCache.kt
@@ -1,8 +1,6 @@
 package com.joying.chat.service
 
 import com.joying.chat.repository.ChatRoomRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
@@ -45,7 +43,7 @@ class ChatRoomPermissionCache(
      * @param memberId 회원 ID
      * @return 권한 여부
      */
-    suspend fun hasPermission(chatRoomId: Long, memberId: Long): Boolean {
+    fun hasPermission(chatRoomId: Long, memberId: Long): Boolean {
         val key = getKey(chatRoomId, memberId)
 
         // 1. Redis 캐시 조회 (1-2ms)
@@ -71,14 +69,11 @@ class ChatRoomPermissionCache(
     /**
      * 채팅방 참여자 정보를 MySQL에서 조회
      */
-    private suspend fun checkPermissionFromDB(chatRoomId: Long, memberId: Long): Boolean {
-        return withContext(Dispatchers.IO) {
-            val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null)
-                ?: return@withContext false
+    private fun checkPermissionFromDB(chatRoomId: Long, memberId: Long): Boolean {
+        val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: return false
 
-            // 구매자 또는 판매자만 권한 있음
-            chatRoom.buyer.getMemberId() == memberId || chatRoom.seller.getMemberId() == memberId
-        }
+        // 구매자 또는 판매자만 권한 있음
+        return chatRoom.buyer.getMemberId() == memberId || chatRoom.seller.getMemberId() == memberId
     }
 
     /**
@@ -86,10 +81,8 @@ class ChatRoomPermissionCache(
      *
      * @param chatRoomId 채팅방 ID
      */
-    suspend fun warmupPermissions(chatRoomId: Long) {
-        val chatRoom = withContext(Dispatchers.IO) {
-            chatRoomRepository.findById(chatRoomId).orElse(null)
-        } ?: return
+    fun warmupPermissions(chatRoomId: Long) {
+        val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: return
 
         val buyerId = chatRoom.buyer.getMemberId()!!
         val sellerId = chatRoom.seller.getMemberId()!!

--- a/backend/src/main/kotlin/com/joying/chat/service/ChatRoomService.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/ChatRoomService.kt
@@ -19,15 +19,13 @@ import com.joying.member.domain.Member
 import com.joying.member.repository.MemberRepository
 import com.joying.product.domain.Product
 import com.joying.product.repository.ProductRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 import java.time.Instant
 
 /**
@@ -45,6 +43,7 @@ class ChatRoomService(
     private val productRepository: ProductRepository,
     private val chatPresenceService: ChatPresenceService,
     private val unreadCountService: UnreadCountService,
+    @Qualifier("chatQueryExecutor") private val queryExecutor: Executor,
     private val productFileRepository: ProductFileRepository,
     private val fileUrlResolver: FileUrlResolver,
     private val permissionCache: ChatRoomPermissionCache,
@@ -110,7 +109,7 @@ class ChatRoomService(
                 logger.info("채팅방 재입장 (요청자): chatRoomId={}, memberId={}", chatRoom.chatRoomId, requestMemberId)
 
                 // 재입장 알림 전송 (비동기)
-                CoroutineScope(Dispatchers.IO).launch {
+                queryExecutor.execute {
                     try {
                         sendRejoinNotification(chatRoom.chatRoomId!!, requestMemberId)
                     } catch (e: Exception) {
@@ -179,7 +178,7 @@ class ChatRoomService(
         )
 
         // 권한 캐시 Warmup (비동기)
-        kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO).launch {
+        queryExecutor.execute {
             try {
                 permissionCache.warmupPermissions(savedChatRoom.chatRoomId!!)
             } catch (e: Exception) {
@@ -247,17 +246,16 @@ class ChatRoomService(
     }
 
     /**
-     * 내 채팅방 목록 조회 (runBlocking 방식)
+     * 내 채팅방 목록 조회
      *
      * 최적화:
      * - Fetch Join으로 Product, Buyer, Seller 한 번에 조회 (N+1 방지)
      * - ProductFile은 배치 조회 (1:N 관계라 Fetch Join 불가)
      * - Redis MGET으로 안읽은 개수 배치 조회
      *
-     * runBlocking 사용 이유:
-     * - Spring MVC 환경에서 SecurityContext 유지
-     * - HTTP Thread에서 응답 반환 보장
-     * - 내부에서 코루틴 기능(병렬 처리) 사용 가능
+     * 예전에는 이 자리를 코루틴이 맡았다. 밑에 있는 저장소가 전부 블로킹이라
+     * 코루틴이 사 주는 것이 없었고, 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더
+     * 쓰고 있었다. 지금은 그냥 부른다.
      *
      * @param memberId 회원 ID
      * @param includeMember 참여자 온라인 상태 포함 여부
@@ -267,7 +265,7 @@ class ChatRoomService(
         memberId: Long,
         includeMember: Boolean = false,
     ): List<ChatRoomResponse> =
-        kotlinx.coroutines.runBlocking {
+        run {
             logger.info("[getMyChatRooms] 시작: memberId={}, includeMember={}", memberId, includeMember)
 
             // JPA Repository 조회 (Blocking이지만 충분히 빠름)
@@ -281,7 +279,7 @@ class ChatRoomService(
             val memberSettingsMap = chatRoomMembers.associateBy { it.chatRoomId }
             logger.info("[getMyChatRooms] memberSettingsMap 생성 완료")
 
-            // Redis에서 안읽은 개수 배치 조회 (suspend fun이므로 코루틴 내에서 호출)
+            // Redis에서 안읽은 개수 배치 조회
             val chatRoomIds = chatRooms.map { it.chatRoomId!! }
             logger.info("[getMyChatRooms] Redis 배치 조회 시작: chatRoomIds={}", chatRoomIds)
             val unreadCountMap = unreadCountService.getBatch(chatRoomIds, memberId)
@@ -361,12 +359,11 @@ class ChatRoomService(
         }
 
     /**
-     * 채팅방 상세 조회 (단일) - runBlocking 방식
+     * 채팅방 상세 조회 (단일)
      *
-     * runBlocking 사용 이유:
-     * - Spring MVC 환경에서 SecurityContext 유지
-     * - HTTP Thread에서 응답 반환 보장
-     * - 내부에서 코루틴 기능(병렬 처리) 사용 가능
+     * 예전에는 이 자리를 코루틴이 맡았다. 밑에 있는 저장소가 전부 블로킹이라
+     * 코루틴이 사 주는 것이 없었고, 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더
+     * 쓰고 있었다. 지금은 그냥 부른다.
      *
      * @param chatRoomId 채팅방 ID
      * @param memberId 회원 ID
@@ -379,7 +376,7 @@ class ChatRoomService(
         includeMember: Boolean = false,
     ): ChatRoomResponse =
         @Suppress("ktlint:standard:max-line-length")
-        kotlinx.coroutines.runBlocking {
+        run {
             // 1. ChatRoom 조회 (Fetch Join으로 Product, Buyer, Seller 한 번에 로드)
             val chatRoom =
                 chatRoomRepository
@@ -391,20 +388,20 @@ class ChatRoomService(
                 throw BusinessException(ErrorCode.FORBIDDEN, "채팅방 접근 권한이 없습니다")
             }
 
-            // 2. Settings와 Redis 병렬 조회 (의존성 없음)
-            val settingsDeferred =
-                async {
+            // 2. Settings와 안읽음 개수는 서로 의존하지 않으므로 동시에 조회한다.
+            val settingsFuture =
+                CompletableFuture.supplyAsync({
                     chatRoomMemberRepository
                         .findByChatRoomIdAndMemberId(chatRoomId, memberId)
                         .orElseThrow { BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "채팅방 설정을 찾을 수 없습니다") }
-                }
-            val unreadCountDeferred =
-                async {
+                }, queryExecutor)
+            val unreadCountFuture =
+                CompletableFuture.supplyAsync({
                     unreadCountService.get(chatRoomId, memberId)
-                }
+                }, queryExecutor)
 
-            val settings = settingsDeferred.await()
-            val unreadCount = unreadCountDeferred.await()
+            val settings = settingsFuture.join()
+            val unreadCount = unreadCountFuture.join()
 
             // 상대방 정보 (Fetch Join으로 이미 로드됨)
             val otherMember =
@@ -500,7 +497,7 @@ class ChatRoomService(
         logger.info("채팅방 나가기 (개별): chatRoomId={}, memberId={}", chatRoomId, memberId)
 
         // 시스템 메시지 저장 (MongoDB) 및 실시간 알림 전송 (비동기)
-        CoroutineScope(Dispatchers.IO).launch {
+        queryExecutor.execute {
             try {
                 // 1. 시스템 메시지 생성 및 저장
                 val systemMessage =
@@ -588,7 +585,7 @@ class ChatRoomService(
             logger.info("채팅방 자동 종료: chatRoomId={}, lastMessageAt={}", chatRoom.chatRoomId, chatRoom.lastMessageAt)
 
             // 시스템 메시지 저장 및 양쪽 멤버에게 실시간 알림 전송 (비동기)
-            CoroutineScope(Dispatchers.IO).launch {
+            queryExecutor.execute {
                 try {
                     // 1. 시스템 메시지 생성 및 저장
                     val systemMessage =
@@ -651,9 +648,9 @@ class ChatRoomService(
      * @param memberId 회원 ID
      * @return 모든 채팅방의 안읽은 메시지 총 개수
      */
-    suspend fun getTotalUnreadCount(memberId: Long): Long {
+    fun getTotalUnreadCount(memberId: Long): Long {
         val chatRoomMembers =
-            withContext(Dispatchers.IO) {
+            run {
                 chatRoomMemberRepository.findByMemberId(memberId)
             }
         val chatRoomIds = chatRoomMembers.map { it.chatRoomId!! } // FK 직접 접근
@@ -780,70 +777,68 @@ class ChatRoomService(
      * @param chatRoomId 채팅방 ID
      * @param memberId 재입장한 회원 ID
      */
-    private suspend fun sendRejoinNotification(
+    private fun sendRejoinNotification(
         chatRoomId: Long,
         memberId: Long,
     ) {
-        withContext(Dispatchers.IO) {
-            try {
-                // 채팅방 정보 조회
-                val chatRoom =
-                    chatRoomRepository
-                        .findById(chatRoomId)
-                        .orElseThrow { BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "채팅방을 찾을 수 없습니다") }
+        try {
+            // 채팅방 정보 조회
+            val chatRoom =
+                chatRoomRepository
+                    .findById(chatRoomId)
+                    .orElseThrow { BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "채팅방을 찾을 수 없습니다") }
 
-                // 재입장한 사용자 닉네임
-                val rejoiningMemberNickname =
-                    if (memberId == chatRoom.buyer.memberId) {
-                        chatRoom.buyer.nickname
-                    } else {
-                        chatRoom.seller.nickname
-                    }
+            // 재입장한 사용자 닉네임
+            val rejoiningMemberNickname =
+                if (memberId == chatRoom.buyer.memberId) {
+                    chatRoom.buyer.nickname
+                } else {
+                    chatRoom.seller.nickname
+                }
 
-                // 상대방 ID 계산
-                val receiverId =
-                    if (memberId == chatRoom.buyer.memberId) {
-                        chatRoom.seller.memberId!!
-                    } else {
-                        chatRoom.buyer.memberId!!
-                    }
+            // 상대방 ID 계산
+            val receiverId =
+                if (memberId == chatRoom.buyer.memberId) {
+                    chatRoom.seller.memberId!!
+                } else {
+                    chatRoom.buyer.memberId!!
+                }
 
-                // 1. 시스템 메시지 생성 및 저장 (MongoDB)
-                val systemMessage =
-                    com.joying.chat.document.ChatMessage.createSystemMessage(
-                        chatRoomId = chatRoomId,
-                        content = "${rejoiningMemberNickname}님이 다시 들어왔습니다",
-                    )
-                systemMessage.createdAt = Instant.now()
+            // 1. 시스템 메시지 생성 및 저장 (MongoDB)
+            val systemMessage =
+                com.joying.chat.document.ChatMessage.createSystemMessage(
+                    chatRoomId = chatRoomId,
+                    content = "${rejoiningMemberNickname}님이 다시 들어왔습니다",
+                )
+            systemMessage.createdAt = Instant.now()
 
-                val savedMessage = chatMessageRepository.save(systemMessage)
+            val savedMessage = chatMessageRepository.save(systemMessage)
 
-                logger.info("재입장 시스템 메시지 MongoDB 저장: chatRoomId={}, memberId={}", chatRoomId, memberId)
+            logger.info("재입장 시스템 메시지 MongoDB 저장: chatRoomId={}, memberId={}", chatRoomId, memberId)
 
-                // 2. Redis Pub/Sub로 발행 (실시간 전달)
-                val messageDto =
-                    com.joying.chat.dto.ChatMessageResponse
-                        .from(savedMessage, null)
-                        .copy(receiverId = receiverId)
-                redisPubSubPublisher.publish(messageDto)
+            // 2. Redis Pub/Sub로 발행 (실시간 전달)
+            val messageDto =
+                com.joying.chat.dto.ChatMessageResponse
+                    .from(savedMessage, null)
+                    .copy(receiverId = receiverId)
+            redisPubSubPublisher.publish(messageDto)
 
-                logger.info("재입장 시스템 메시지 Redis Pub/Sub 발행: chatRoomId={}, receiverId={}", chatRoomId, receiverId)
+            logger.info("재입장 시스템 메시지 Redis Pub/Sub 발행: chatRoomId={}, receiverId={}", chatRoomId, receiverId)
 
-                // 3. 채팅방 상태 변경 이벤트 전송 (WebSocket)
-                val event =
-                    ChatRoomStatusEvent(
-                        chatRoomId = chatRoomId,
-                        eventType = ChatRoomStatusEvent.EventType.MEMBER_REJOINED,
-                        memberId = memberId,
-                        memberNickname = rejoiningMemberNickname,
-                    )
+            // 3. 채팅방 상태 변경 이벤트 전송 (WebSocket)
+            val event =
+                ChatRoomStatusEvent(
+                    chatRoomId = chatRoomId,
+                    eventType = ChatRoomStatusEvent.EventType.MEMBER_REJOINED,
+                    memberId = memberId,
+                    memberNickname = rejoiningMemberNickname,
+                )
 
-                chatBroadcaster.toUser(receiverId, "/queue/chatroom-status", event)
+            chatBroadcaster.toUser(receiverId, "/queue/chatroom-status", event)
 
-                logger.info("채팅방 재입장 WebSocket 알림 전송 완료: chatRoomId={}, memberId={}, to={}", chatRoomId, memberId, receiverId)
-            } catch (e: Exception) {
-                logger.error("채팅방 재입장 알림 전송 실패: chatRoomId={}, memberId={}, error={}", chatRoomId, memberId, e.message, e)
-            }
+            logger.info("채팅방 재입장 WebSocket 알림 전송 완료: chatRoomId={}, memberId={}, to={}", chatRoomId, memberId, receiverId)
+        } catch (e: Exception) {
+            logger.error("채팅방 재입장 알림 전송 실패: chatRoomId={}, memberId={}, error={}", chatRoomId, memberId, e.message, e)
         }
     }
 }

--- a/backend/src/main/kotlin/com/joying/chat/service/ChatService.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/ChatService.kt
@@ -14,11 +14,8 @@ import com.joying.chat.repository.ChatRoomMemberRepository
 import com.joying.chat.repository.ChatRoomRepository
 import com.joying.common.exception.BusinessException
 import com.joying.common.exception.ErrorCode
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.query.Criteria
 import org.springframework.data.mongodb.core.query.Query
@@ -26,6 +23,7 @@ import org.springframework.data.mongodb.core.query.Update
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.Executor
 import java.time.Instant
 
 /**
@@ -40,6 +38,7 @@ import java.time.Instant
 @Service
 class ChatService(
     private val chatRoomRepository: ChatRoomRepository,
+    @Qualifier("chatQueryExecutor") private val queryExecutor: Executor,
     private val chatRoomMemberRepository: ChatRoomMemberRepository,
     private val chatMessageRepository: ChatMessageRepository,
     private val redisPubSubPublisher: RedisPubSubPublisher,
@@ -67,7 +66,7 @@ class ChatService(
      * @param request 메시지 내용
      * @return 저장된 메시지 DTO
      */
-    suspend fun sendMessage(
+    fun sendMessage(
         chatRoomId: Long,
         senderId: Long,
         request: SendMessageRequest,
@@ -84,7 +83,7 @@ class ChatService(
 
         // 2. 채팅방 활성 상태 확인 (권한 확인 시 이미 조회했으므로 캐시에서 가져올 수 있음)
         val chatRoom =
-            withContext(Dispatchers.IO) {
+            run {
                 chatRoomRepository
                     .findById(chatRoomId)
                     .orElseThrow { BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "채팅방을 찾을 수 없습니다") }
@@ -102,7 +101,7 @@ class ChatService(
         }
 
         // 본인이 나간 상태인지 확인
-        val senderMember = withContext(Dispatchers.IO) {
+        val senderMember = run {
             chatRoomMemberRepository
                 .findByChatRoomIdAndMemberId(chatRoomId, senderId)
                 .orElse(null)
@@ -113,7 +112,7 @@ class ChatService(
         }
 
         // 상대방이 나간 상태인지 확인
-        val receiverMember = withContext(Dispatchers.IO) {
+        val receiverMember = run {
             chatRoomMemberRepository
                 .findByChatRoomIdAndMemberId(chatRoomId, receiverId)
                 .orElse(null)
@@ -165,18 +164,16 @@ class ChatService(
         // 현재 시간 설정
         chatMessage.createdAt = Instant.now()
 
-        // 3. MongoDB에 저장 (영구 저장) - withContext로 blocking I/O 처리
+        // 3. MongoDB에 저장 (영구 저장)
         val savedMessage =
-            withContext(Dispatchers.IO) {
+            run {
                 chatMessageRepository.save(chatMessage)
             }
 
         // 4. 답장 대상 메시지 조회 (있을 경우)
         val replyMessage =
             savedMessage.replyToMessageId?.let { replyId ->
-                withContext(Dispatchers.IO) {
-                    chatMessageRepository.findById(replyId).orElse(null)
-                }
+                chatMessageRepository.findById(replyId).orElse(null)
             }
 
         // 5. DTO 변환 (답장 정보 + 수신자 정보 포함)
@@ -197,7 +194,7 @@ class ChatService(
 
         // 9. 푸시 알림 전송 (비동기) - 푸시 서비스가 활성화된 경우에만
         if (webPushService.isPushEnabled()) {
-            CoroutineScope(Dispatchers.IO).launch {
+            queryExecutor.execute {
                 try {
                     sendPushNotification(chatRoomId, receiverId, senderId, savedMessage)
                 } catch (e: Exception) {
@@ -207,7 +204,7 @@ class ChatService(
         }
 
         // 10. lastMessage 업데이트 (비동기) - 20-30ms 절감
-        CoroutineScope(Dispatchers.IO).launch {
+        queryExecutor.execute {
             try {
                 updateLastMessageAsync(chatRoomId, savedMessage.content, savedMessage.createdAt!!)
             } catch (e: Exception) {
@@ -240,21 +237,19 @@ class ChatService(
      * lastMessage 비동기 업데이트
      * (메시지 전송 응답 속도에 영향 없음)
      */
-    private suspend fun updateLastMessageAsync(
+    private fun updateLastMessageAsync(
         chatRoomId: Long,
         content: String,
         createdAt: Instant,
     ) {
-        withContext(Dispatchers.IO) {
-            val chatRoom =
-                chatRoomRepository.findById(chatRoomId).orElse(null)
-                    ?: return@withContext
+        val chatRoom =
+            chatRoomRepository.findById(chatRoomId).orElse(null)
+                ?: return
 
-            chatRoom.updateLastMessage(content, createdAt)
-            chatRoomRepository.save(chatRoom)
+        chatRoom.updateLastMessage(content, createdAt)
+        chatRoomRepository.save(chatRoom)
 
-            logger.debug("lastMessage 비동기 업데이트 완료: chatRoomId={}", chatRoomId)
-        }
+        logger.debug("lastMessage 비동기 업데이트 완료: chatRoomId={}", chatRoomId)
     }
 
     /**
@@ -282,9 +277,9 @@ class ChatService(
 
         // MongoDB 메시지 읽음 처리 (비동기)
         // 상대방이 보낸 메시지들을 isRead = true로 업데이트
-        CoroutineScope(Dispatchers.IO).launch {
+        queryExecutor.execute {
             try {
-                val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: return@launch
+                val chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null) ?: return@execute
 
                 // 상대방 ID 계산
                 val otherMemberId = if (memberId == chatRoom.buyer.memberId) {
@@ -375,81 +370,79 @@ class ChatService(
      * 추가 조건:
      * - 알림이 꺼져 있으면 전송 안함
      */
-    private suspend fun sendPushNotification(
+    private fun sendPushNotification(
         chatRoomId: Long,
         receiverId: Long,
         senderId: Long,
         message: ChatMessage,
     ) {
-        withContext(Dispatchers.IO) {
-            // 1. 수신자의 알림 설정 확인
-            val receiverMember =
-                chatRoomMemberRepository
-                    .findByChatRoomIdAndMemberId(chatRoomId, receiverId)
-                    .orElse(null) ?: return@withContext
+        // 1. 수신자의 알림 설정 확인
+        val receiverMember =
+            chatRoomMemberRepository
+                .findByChatRoomIdAndMemberId(chatRoomId, receiverId)
+                .orElse(null) ?: return
 
-            // 알림이 꺼져 있으면 전송하지 않음
-            if (receiverMember.isMuted) {
-                logger.debug("푸시 알림 건너뜀 (알림 꺼짐): chatRoomId={}, receiverId={}", chatRoomId, receiverId)
-                return@withContext
-            }
-
-            // 2. 수신자가 현재 이 채팅방을 보고 있는지 확인
-            // 현재 채팅방 화면을 보고 있으면 푸시 알림 불필요 (이미 실시간 메시지로 받음)
-            val isViewingThisChatRoom = chatPresenceService.isViewingChatRoom(receiverId, chatRoomId)
-            if (isViewingThisChatRoom) {
-                logger.debug("푸시 알림 건너뜀 (채팅방 보는 중): chatRoomId={}, receiverId={}", chatRoomId, receiverId)
-                return@withContext
-            }
-
-            // 3. 오프라인이거나 다른 채팅방을 보고 있으면 푸시 전송
-            // (isViewingThisChatRoom = false 이므로 여기 도달하면 푸시 전송해야 함)
-
-            // 3. 발신자 정보 조회 (프로필 이미지까지 Fetch Join)
-            // LazyInitializationException 방지: withContext(Dispatchers.IO)에서 Hibernate Session이 끊기므로
-            // Member.profileImage (File 엔티티)까지 미리 로드해야 함
-            val chatRoom = chatRoomRepository.findByIdWithProfileImages(chatRoomId).orElse(null) ?: return@withContext
-            val sender =
-                if (senderId == chatRoom.buyer.memberId) {
-                    chatRoom.buyer
-                } else {
-                    chatRoom.seller
-                }
-
-            // 4. 발신자 프로필 이미지 URL 가져오기
-            val senderProfileUrl = sender.profileImage?.let { file ->
-                "${file.directory}/${file.fileName}"
-            } ?: sender.kakaoProfileImageUrl
-
-            // 5. 푸시 알림 페이로드 생성
-            val payload = createPushPayload(sender.nickname, senderProfileUrl, message, chatRoomId)
-
-            // 6. WebSocket 알림 전송 (1순위 - 온라인일 때 즉시 전달)
-            // LINE, Slack 등 대기업 메신저 표준 구현 방식
-            // 온라인 사용자는 WebSocket으로 즉시 받음 (빠름, 수십ms)
-            try {
-                val notificationData = mapOf(
-                    "type" to "PUSH_NOTIFICATION",
-                    "title" to payload.title,
-                    "body" to payload.body,
-                    "icon" to payload.icon,
-                    "image" to payload.image,
-                    "badge" to payload.badge,
-                    "tag" to payload.tag,
-                    "data" to payload.data
-                )
-                chatBroadcaster.toUser(receiverId, "/queue/notifications", notificationData)
-                logger.debug("WebSocket 알림 전송 완료 (1순위): receiverId={}", receiverId)
-            } catch (e: Exception) {
-                logger.debug("WebSocket 알림 전송 실패 (정상 - 오프라인일 수 있음): receiverId={}", receiverId)
-                // 실패해도 괜찮음 (오프라인이거나 WebSocket 연결 없음)
-            }
-
-            // 7. 푸시 알림 전송 (2순위 - 오프라인/백그라운드 대비 Fallback)
-            // 오프라인 사용자나 백그라운드에서도 알림 받을 수 있도록 함 (느림, 수백ms)
-            webPushService.sendNotification(receiverId, payload)
-            logger.info("푸시 알림 전송 (2순위 Fallback): chatRoomId={}, receiverId={}, type={}", chatRoomId, receiverId, message.type)
+        // 알림이 꺼져 있으면 전송하지 않음
+        if (receiverMember.isMuted) {
+            logger.debug("푸시 알림 건너뜀 (알림 꺼짐): chatRoomId={}, receiverId={}", chatRoomId, receiverId)
+            return
         }
+
+        // 2. 수신자가 현재 이 채팅방을 보고 있는지 확인
+        // 현재 채팅방 화면을 보고 있으면 푸시 알림 불필요 (이미 실시간 메시지로 받음)
+        val isViewingThisChatRoom = chatPresenceService.isViewingChatRoom(receiverId, chatRoomId)
+        if (isViewingThisChatRoom) {
+            logger.debug("푸시 알림 건너뜀 (채팅방 보는 중): chatRoomId={}, receiverId={}", chatRoomId, receiverId)
+            return
+        }
+
+        // 3. 오프라인이거나 다른 채팅방을 보고 있으면 푸시 전송
+        // (isViewingThisChatRoom = false 이므로 여기 도달하면 푸시 전송해야 함)
+
+        // 3. 발신자 정보 조회 (프로필 이미지까지 Fetch Join)
+        // LazyInitializationException 방지: 트랜잭션 밖에서 지연 로딩이 끊기므로
+        // Member.profileImage (File 엔티티)까지 미리 로드해야 함
+        val chatRoom = chatRoomRepository.findByIdWithProfileImages(chatRoomId).orElse(null) ?: return
+        val sender =
+            if (senderId == chatRoom.buyer.memberId) {
+                chatRoom.buyer
+            } else {
+                chatRoom.seller
+            }
+
+        // 4. 발신자 프로필 이미지 URL 가져오기
+        val senderProfileUrl = sender.profileImage?.let { file ->
+            "${file.directory}/${file.fileName}"
+        } ?: sender.kakaoProfileImageUrl
+
+        // 5. 푸시 알림 페이로드 생성
+        val payload = createPushPayload(sender.nickname, senderProfileUrl, message, chatRoomId)
+
+        // 6. WebSocket 알림 전송 (1순위 - 온라인일 때 즉시 전달)
+        // LINE, Slack 등 대기업 메신저 표준 구현 방식
+        // 온라인 사용자는 WebSocket으로 즉시 받음 (빠름, 수십ms)
+        try {
+            val notificationData = mapOf(
+                "type" to "PUSH_NOTIFICATION",
+                "title" to payload.title,
+                "body" to payload.body,
+                "icon" to payload.icon,
+                "image" to payload.image,
+                "badge" to payload.badge,
+                "tag" to payload.tag,
+                "data" to payload.data
+            )
+            chatBroadcaster.toUser(receiverId, "/queue/notifications", notificationData)
+            logger.debug("WebSocket 알림 전송 완료 (1순위): receiverId={}", receiverId)
+        } catch (e: Exception) {
+            logger.debug("WebSocket 알림 전송 실패 (정상 - 오프라인일 수 있음): receiverId={}", receiverId)
+            // 실패해도 괜찮음 (오프라인이거나 WebSocket 연결 없음)
+        }
+
+        // 7. 푸시 알림 전송 (2순위 - 오프라인/백그라운드 대비 Fallback)
+        // 오프라인 사용자나 백그라운드에서도 알림 받을 수 있도록 함 (느림, 수백ms)
+        webPushService.sendNotification(receiverId, payload)
+        logger.info("푸시 알림 전송 (2순위 Fallback): chatRoomId={}, receiverId={}, type={}", chatRoomId, receiverId, message.type)
     }
 
     /**
@@ -460,60 +453,58 @@ class ChatService(
      * @param chatRoomId 채팅방 ID
      * @param memberId 재입장한 회원 ID
      */
-    suspend fun sendRejoinNotification(chatRoomId: Long, memberId: Long) {
-        withContext(Dispatchers.IO) {
-            try {
-                // 채팅방 정보 조회
-                val chatRoom = chatRoomRepository.findById(chatRoomId)
-                    .orElseThrow { BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "채팅방을 찾을 수 없습니다") }
+    fun sendRejoinNotification(chatRoomId: Long, memberId: Long) {
+        try {
+            // 채팅방 정보 조회
+            val chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow { BusinessException(ErrorCode.RESOURCE_NOT_FOUND, "채팅방을 찾을 수 없습니다") }
 
-                // 재입장한 사용자 닉네임
-                val rejoiningMemberNickname = if (memberId == chatRoom.buyer.memberId) {
-                    chatRoom.buyer.nickname
-                } else {
-                    chatRoom.seller.nickname
-                }
-
-                // 상대방 ID 계산
-                val receiverId = if (memberId == chatRoom.buyer.memberId) {
-                    chatRoom.seller.memberId!!
-                } else {
-                    chatRoom.buyer.memberId!!
-                }
-
-                // 1. 시스템 메시지 생성 및 저장 (MongoDB)
-                val systemMessage = ChatMessage.createSystemMessage(
-                    chatRoomId = chatRoomId,
-                    content = "${rejoiningMemberNickname}님이 다시 들어왔습니다"
-                )
-                systemMessage.createdAt = Instant.now()
-
-                val savedMessage = chatMessageRepository.save(systemMessage)
-
-                logger.info("재입장 시스템 메시지 MongoDB 저장: chatRoomId={}, memberId={}", chatRoomId, memberId)
-
-                // 2. Redis Pub/Sub로 발행 (실시간 전달)
-                val messageDto = ChatMessageResponse.from(savedMessage, null)
-                    .copy(receiverId = receiverId)
-                redisPubSubPublisher.publish(messageDto)
-
-                logger.info("재입장 시스템 메시지 Redis Pub/Sub 발행: chatRoomId={}, receiverId={}", chatRoomId, receiverId)
-
-                // 3. 채팅방 상태 변경 이벤트 전송 (WebSocket)
-                val event = ChatRoomStatusEvent(
-                    chatRoomId = chatRoomId,
-                    eventType = ChatRoomStatusEvent.EventType.MEMBER_REJOINED,
-                    memberId = memberId,
-                    memberNickname = rejoiningMemberNickname
-                )
-
-                chatBroadcaster.toUser(receiverId, "/queue/chatroom-status", event)
-
-                logger.info("채팅방 재입장 WebSocket 알림 전송 완료: chatRoomId={}, memberId={}, to={}", chatRoomId, memberId, receiverId)
-            } catch (e: Exception) {
-                logger.error("채팅방 재입장 알림 전송 실패: chatRoomId={}, memberId={}, error={}", chatRoomId, memberId, e.message, e)
-                throw e
+            // 재입장한 사용자 닉네임
+            val rejoiningMemberNickname = if (memberId == chatRoom.buyer.memberId) {
+                chatRoom.buyer.nickname
+            } else {
+                chatRoom.seller.nickname
             }
+
+            // 상대방 ID 계산
+            val receiverId = if (memberId == chatRoom.buyer.memberId) {
+                chatRoom.seller.memberId!!
+            } else {
+                chatRoom.buyer.memberId!!
+            }
+
+            // 1. 시스템 메시지 생성 및 저장 (MongoDB)
+            val systemMessage = ChatMessage.createSystemMessage(
+                chatRoomId = chatRoomId,
+                content = "${rejoiningMemberNickname}님이 다시 들어왔습니다"
+            )
+            systemMessage.createdAt = Instant.now()
+
+            val savedMessage = chatMessageRepository.save(systemMessage)
+
+            logger.info("재입장 시스템 메시지 MongoDB 저장: chatRoomId={}, memberId={}", chatRoomId, memberId)
+
+            // 2. Redis Pub/Sub로 발행 (실시간 전달)
+            val messageDto = ChatMessageResponse.from(savedMessage, null)
+                .copy(receiverId = receiverId)
+            redisPubSubPublisher.publish(messageDto)
+
+            logger.info("재입장 시스템 메시지 Redis Pub/Sub 발행: chatRoomId={}, receiverId={}", chatRoomId, receiverId)
+
+            // 3. 채팅방 상태 변경 이벤트 전송 (WebSocket)
+            val event = ChatRoomStatusEvent(
+                chatRoomId = chatRoomId,
+                eventType = ChatRoomStatusEvent.EventType.MEMBER_REJOINED,
+                memberId = memberId,
+                memberNickname = rejoiningMemberNickname
+            )
+
+            chatBroadcaster.toUser(receiverId, "/queue/chatroom-status", event)
+
+            logger.info("채팅방 재입장 WebSocket 알림 전송 완료: chatRoomId={}, memberId={}, to={}", chatRoomId, memberId, receiverId)
+        } catch (e: Exception) {
+            logger.error("채팅방 재입장 알림 전송 실패: chatRoomId={}, memberId={}, error={}", chatRoomId, memberId, e.message, e)
+            throw e
         }
     }
 

--- a/backend/src/main/kotlin/com/joying/chat/service/RedisPubSubPublisher.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/RedisPubSubPublisher.kt
@@ -2,8 +2,6 @@ package com.joying.chat.service
 
 import com.joying.chat.config.RedisPubSubConfig
 import com.joying.chat.dto.ChatMessageResponse
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
@@ -27,31 +25,29 @@ class RedisPubSubPublisher(
      *
      * @param message 발행할 메시지
      */
-    suspend fun publish(message: ChatMessageResponse) {
-        withContext(Dispatchers.IO) {
-            try {
-                // Redis Pub/Sub로 발행 (PUBLISH 명령)
-                chatMessageRedisTemplate.convertAndSend(
-                    RedisPubSubConfig.CHAT_MESSAGE_CHANNEL,
-                    message
-                )
+    fun publish(message: ChatMessageResponse) {
+        try {
+            // Redis Pub/Sub로 발행 (PUBLISH 명령)
+            chatMessageRedisTemplate.convertAndSend(
+                RedisPubSubConfig.CHAT_MESSAGE_CHANNEL,
+                message
+            )
 
-                logger.debug(
-                    "Redis Pub/Sub 발행 성공: chatRoomId={}, senderId={}, messageId={}",
-                    message.chatRoomId,
-                    message.senderId,
-                    message.id
-                )
-            } catch (e: Exception) {
-                logger.error(
-                    "Redis Pub/Sub 발행 실패: chatRoomId={}, senderId={}, error={}",
-                    message.chatRoomId,
-                    message.senderId,
-                    e.message,
-                    e
-                )
-                throw RuntimeException("메시지 발행 실패", e)
-            }
+            logger.debug(
+                "Redis Pub/Sub 발행 성공: chatRoomId={}, senderId={}, messageId={}",
+                message.chatRoomId,
+                message.senderId,
+                message.id
+            )
+        } catch (e: Exception) {
+            logger.error(
+                "Redis Pub/Sub 발행 실패: chatRoomId={}, senderId={}, error={}",
+                message.chatRoomId,
+                message.senderId,
+                e.message,
+                e
+            )
+            throw RuntimeException("메시지 발행 실패", e)
         }
     }
 }

--- a/backend/src/main/kotlin/com/joying/chat/service/UnreadCountService.kt
+++ b/backend/src/main/kotlin/com/joying/chat/service/UnreadCountService.kt
@@ -2,13 +2,12 @@ package com.joying.chat.service
 
 import com.joying.chat.repository.ChatMessageRepository
 import com.joying.chat.repository.ChatRoomMemberRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
 /**
@@ -23,7 +22,8 @@ import java.util.concurrent.TimeUnit
 class UnreadCountService(
     private val redis: RedisTemplate<String, String>,
     private val chatMessageRepository: ChatMessageRepository,
-    private val chatRoomMemberRepository: ChatRoomMemberRepository
+    private val chatRoomMemberRepository: ChatRoomMemberRepository,
+    @Qualifier("chatQueryExecutor") private val queryExecutor: Executor
 ) {
     private val logger = LoggerFactory.getLogger(UnreadCountService::class.java)
 
@@ -83,7 +83,7 @@ class UnreadCountService(
      * @param memberId 회원 ID
      * @return 안읽은 메시지 개수
      */
-    suspend fun get(chatRoomId: Long, memberId: Long): Long {
+    fun get(chatRoomId: Long, memberId: Long): Long {
         val key = getKey(chatRoomId, memberId)
 
         // 1. Redis 조회 (캐시 히트)
@@ -108,7 +108,7 @@ class UnreadCountService(
      * @param memberId 회원 ID
      * @return 채팅방별 안읽은 개수 (chatRoomId -> count)
      */
-    suspend fun getBatch(
+    fun getBatch(
         chatRoomIds: List<Long>,
         memberId: Long
     ): Map<Long, Long> {
@@ -154,15 +154,15 @@ class UnreadCountService(
 
         // 캐시 미스 → MongoDB에서 병렬 계산
         if (missedIds.isNotEmpty()) {
-            coroutineScope {
-                missedIds.map { chatRoomId ->
-                    async {
-                        chatRoomId to warmup(chatRoomId, memberId)
-                    }
-                }.forEach { deferred ->
-                    val (chatRoomId, count) = deferred.await()
-                    result[chatRoomId] = count
-                }
+            // 방마다 저장소를 봐야 한다. 순차로 하면 방 수만큼 지연이 더해진다.
+            // 서로 의존하지 않으므로 동시에 날리고 전부 모은다.
+            val futures = missedIds.map { chatRoomId ->
+                CompletableFuture.supplyAsync({ chatRoomId to warmup(chatRoomId, memberId) }, queryExecutor)
+            }
+            CompletableFuture.allOf(*futures.toTypedArray()).join()
+            futures.forEach { future ->
+                val (chatRoomId, count) = future.join()
+                result[chatRoomId] = count
             }
         }
 
@@ -178,15 +178,13 @@ class UnreadCountService(
      * @param memberId 회원 ID
      * @return 안읽은 메시지 개수
      */
-    private suspend fun warmup(chatRoomId: Long, memberId: Long): Long {
+    private fun warmup(chatRoomId: Long, memberId: Long): Long {
         logger.info("[warmup] 시작: chatRoomId={}, memberId={}", chatRoomId, memberId)
 
         try {
-            val member = withContext(Dispatchers.IO) {
-                chatRoomMemberRepository
-                    .findByChatRoomIdAndMemberId(chatRoomId, memberId)
-                    .orElse(null)
-            }
+            val member = chatRoomMemberRepository
+                .findByChatRoomIdAndMemberId(chatRoomId, memberId)
+                .orElse(null)
 
             logger.info("[warmup] chatRoomMember 조회 완료: chatRoomId={}, member exists={}", chatRoomId, member != null)
 
@@ -199,14 +197,12 @@ class UnreadCountService(
             // MongoDB에서 실제 안읽은 개수 계산 (상대방이 보낸 메시지만)
             logger.info("[warmup] MongoDB 카운트 쿼리 시작: chatRoomId={}, lastReadAt={}, memberId={}", chatRoomId, member.lastReadAt, memberId)
             val actualCount = if (member.lastReadAt != null) {
-                withContext(Dispatchers.IO) {
-                    // 본인이 보낸 메시지는 제외하고 카운트
-                    chatMessageRepository.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(
-                        chatRoomId,
-                        member.lastReadAt!!,
-                        memberId  // 본인 ID 제외
-                    )
-                }
+                // 본인이 보낸 메시지는 제외하고 카운트
+                chatMessageRepository.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(
+                    chatRoomId,
+                    member.lastReadAt!!,
+                    memberId  // 본인 ID 제외
+                )
             } else {
                 logger.info("[warmup] lastReadAt이 null이므로 0 반환")
                 0L

--- a/backend/src/main/kotlin/com/joying/chat/websocket/ChatWebSocketHandler.kt
+++ b/backend/src/main/kotlin/com/joying/chat/websocket/ChatWebSocketHandler.kt
@@ -5,10 +5,9 @@ import com.joying.chat.broadcast.ChatBroadcaster
 import com.joying.chat.dto.SendMessageRequest
 import com.joying.chat.service.ChatPresenceService
 import com.joying.chat.service.ChatService
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import java.util.concurrent.Executor
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
@@ -24,6 +23,7 @@ import org.springframework.stereotype.Controller
 @Controller
 class ChatWebSocketHandler(
     private val chatService: ChatService,
+    @Qualifier("chatQueryExecutor") private val queryExecutor: Executor,
     private val messagingTemplate: SimpMessagingTemplate,
     private val chatBroadcaster: ChatBroadcaster,
     private val chatPresenceService: ChatPresenceService
@@ -57,7 +57,7 @@ class ChatWebSocketHandler(
         )
 
         // 비동기로 메시지 전송 (MongoDB 저장 + Redis Pub/Sub 발행)
-        CoroutineScope(Dispatchers.IO).launch {
+        queryExecutor.execute {
             try {
                 val message = chatService.sendMessage(chatRoomId, memberId, request)
 

--- a/backend/src/main/kotlin/com/joying/payment/event/PaymentEventListener.kt
+++ b/backend/src/main/kotlin/com/joying/payment/event/PaymentEventListener.kt
@@ -7,7 +7,6 @@ import com.joying.chat.service.ChatService
 import com.joying.member.repository.MemberRepository
 import com.joying.payment.service.PaymentService
 import com.joying.product.repository.ProductRepository
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -80,13 +79,11 @@ class PaymentEventListener(
                 return
             }
 
-            runBlocking {
-                chatService.sendMessage(
-                    chatRoomId = chatRoomId,
-                    senderId = event.buyerId, // 구매자 ID로 전송
-                    request = messageRequest
-                )
-            }
+            chatService.sendMessage(
+                chatRoomId = chatRoomId,
+                senderId = event.buyerId, // 구매자 ID로 전송
+                request = messageRequest
+            )
 
             logger.info("[결제 완료 메시지 전송 완료] chatRoomId={}, paymentId={}", chatRoom.chatRoomId, event.paymentId)
 

--- a/backend/src/test/kotlin/com/joying/chat/service/ChatRoomPermissionCacheTest.kt
+++ b/backend/src/test/kotlin/com/joying/chat/service/ChatRoomPermissionCacheTest.kt
@@ -3,7 +3,6 @@ package com.joying.chat.service
 import com.joying.chat.domain.ChatRoom
 import com.joying.chat.repository.ChatRoomRepository
 import com.joying.member.domain.Member
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -62,7 +61,7 @@ class ChatRoomPermissionCacheTest {
 
     @Test
     @DisplayName("캐시에 ALLOWED가 있으면 저장소를 보지 않는다")
-    fun cacheHitSkipsDatabase() = runBlocking<Unit> {
+    fun cacheHitSkipsDatabase() {
         whenever(valueOps.get(key(buyerId))).thenReturn("ALLOWED")
 
         assertThat(cache.hasPermission(roomId, buyerId)).isTrue()
@@ -71,7 +70,7 @@ class ChatRoomPermissionCacheTest {
 
     @Test
     @DisplayName("캐시에 DENIED가 있으면 거절이다")
-    fun cachedDenialIsHonored() = runBlocking<Unit> {
+    fun cachedDenialIsHonored() {
         whenever(valueOps.get(key(strangerId))).thenReturn("DENIED")
 
         assertThat(cache.hasPermission(roomId, strangerId)).isFalse()
@@ -80,7 +79,7 @@ class ChatRoomPermissionCacheTest {
 
     @Test
     @DisplayName("캐시가 비었으면 저장소를 보고 결과를 캐싱한다")
-    fun cacheMissChecksDatabaseAndCaches() = runBlocking<Unit> {
+    fun cacheMissChecksDatabaseAndCaches() {
         val room = roomWith(buyerId, sellerId)
         whenever(valueOps.get(key(buyerId))).thenReturn(null)
         whenever(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(room))
@@ -91,7 +90,7 @@ class ChatRoomPermissionCacheTest {
 
     @Test
     @DisplayName("방에 없는 사람은 거절이고 그것도 캐싱한다")
-    fun strangerIsDeniedAndCached() = runBlocking<Unit> {
+    fun strangerIsDeniedAndCached() {
         val room = roomWith(buyerId, sellerId)
         whenever(valueOps.get(key(strangerId))).thenReturn(null)
         whenever(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(room))
@@ -102,7 +101,7 @@ class ChatRoomPermissionCacheTest {
 
     @Test
     @DisplayName("방이 없으면 거절이다")
-    fun missingRoomIsDenied() = runBlocking<Unit> {
+    fun missingRoomIsDenied() {
         whenever(valueOps.get(key(buyerId))).thenReturn(null)
         whenever(chatRoomRepository.findById(roomId)).thenReturn(Optional.empty())
 
@@ -111,7 +110,7 @@ class ChatRoomPermissionCacheTest {
 
     @Test
     @DisplayName("알려진 결함: 판정 근거가 buyer/seller뿐이라 방을 나갔는지는 보지 않는다")
-    fun knownDefect_ignoresWhetherMemberLeft() = runBlocking<Unit> {
+    fun knownDefect_ignoresWhetherMemberLeft() {
         // 판정은 chatRoom의 buyer/seller와 같은 사람인가만 본다. ChatRoomMember의
         // isLeft도, 방의 status도 보지 않는다.
         //

--- a/backend/src/test/kotlin/com/joying/chat/service/UnreadCountServiceTest.kt
+++ b/backend/src/test/kotlin/com/joying/chat/service/UnreadCountServiceTest.kt
@@ -3,7 +3,6 @@ package com.joying.chat.service
 import com.joying.chat.domain.ChatRoomMember
 import com.joying.chat.repository.ChatMessageRepository
 import com.joying.chat.repository.ChatRoomMemberRepository
-import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -49,7 +48,9 @@ class UnreadCountServiceTest {
         messageRepository = mock()
         memberRepository = mock()
         whenever(redis.opsForValue()).thenReturn(valueOps)
-        service = UnreadCountService(redis, messageRepository, memberRepository)
+        // 코루틴을 걷어내면서 병렬 조회가 CompletableFuture로 바뀌었다.
+        // 테스트에서는 같은 스레드에서 바로 실행해 순서를 예측 가능하게 둔다.
+        service = UnreadCountService(redis, messageRepository, memberRepository) { it.run() }
     }
 
     @Test
@@ -80,7 +81,7 @@ class UnreadCountServiceTest {
 
     @Test
     @DisplayName("캐시에 값이 있으면 그 값을 그대로 돌려주고 저장소를 보지 않는다")
-    fun returnsCachedValueWithoutTouchingStores() = runBlocking<Unit> {
+    fun returnsCachedValueWithoutTouchingStores() {
         whenever(valueOps.get(key)).thenReturn("7")
 
         val count = service.get(roomId, memberId)
@@ -91,7 +92,7 @@ class UnreadCountServiceTest {
 
     @Test
     @DisplayName("캐시가 비었고 방 멤버가 아니면 0이다")
-    fun returnsZeroWhenNotAMember() = runBlocking<Unit> {
+    fun returnsZeroWhenNotAMember() {
         whenever(valueOps.get(key)).thenReturn(null)
         whenever(memberRepository.findByChatRoomIdAndMemberId(roomId, memberId))
             .thenReturn(Optional.empty())
@@ -101,7 +102,7 @@ class UnreadCountServiceTest {
 
     @Test
     @DisplayName("캐시가 비었으면 저장소에서 세되 본인이 보낸 것은 빼고 센다")
-    fun countsOnlyMessagesFromOthers() = runBlocking<Unit> {
+    fun countsOnlyMessagesFromOthers() {
         val lastReadAt = Instant.parse("2026-01-01T00:00:00Z")
         val member = mock<ChatRoomMember>()
         whenever(member.lastReadAt).thenReturn(lastReadAt)
@@ -120,7 +121,7 @@ class UnreadCountServiceTest {
 
     @Test
     @DisplayName("알려진 결함: 방을 한 번도 안 열었으면 쌓인 메시지가 있어도 0으로 본다")
-    fun knownDefect_zeroWhenNeverOpened() = runBlocking<Unit> {
+    fun knownDefect_zeroWhenNeverOpened() {
         // lastReadAt이 null이면 저장소를 보지 않고 0을 돌려준다. 방을 한 번도 안 연
         // 사람은 메시지가 아무리 쌓여도 배지가 0으로 보인다.
         //


### PR DESCRIPTION
Closes #26
Base: #29

## 무엇이 문제였나

채팅 모듈은 코루틴을 쓰려고 Kotlin으로 짰는데 밑이 전부 블로킹이다.

```
ChatMessageRepository    MongoRepository    블로킹
ChatRoomRepository       JpaRepository      블로킹
ChatRoomMemberRepository JpaRepository      블로킹
```

**`runBlocking`(19)이 `suspend fun`(17)보다 많았다.** suspend로 만들어 조합한 게 아니라, 만들어 놓고 매번 블로킹 컨텍스트에서 불러 다시 막고 있었다. 코루틴이 사 주는 건 스레드를 안 잡고 기다리는 것인데 `runBlocking`은 그 스레드를 잡는다.

`withContext(Dispatchers.IO)`도 블로킹 호출을 다른 풀로 옮기는 것뿐이라, 톰캣 워커를 잡아 둔 채 IO 스레드를 하나 더 썼다.

## 결과

| | 전 | 후 |
|---|---|---|
| `withContext(Dispatchers.IO)` | 37 | 0 |
| `runBlocking` | 19 | 0 |
| `suspend fun` | 17 | 0 |
| `CoroutineScope(...).launch` | 8 | 0 |
| `async` / `await` | 6 | 0 (CompletableFuture로) |

**코루틴 흔적 0건.** 라이브러리 의존성도 뺐다.

## 남긴 것

방 상세를 열 때 설정과 안읽음은 서로 의존하지 않는다. 방 목록도 방마다 안읽음을 세야 한다. **이 병렬 조회만 `CompletableFuture`로 남겼다.**

풀 크기를 묶었다. 밑이 블로킹이라 무제한이면 방이 많은 사용자 하나가 커넥션을 전부 가져갈 수 있다. 큐가 차면 부른 스레드가 직접 처리한다 — 조회를 버리면 안읽음이 0으로 보인다.

## 곁작업도 관리되게 했다

`CoroutineScope(Dispatchers.IO).launch`가 8곳 있었다. 매번 새 스코프라 취소도 감독도 없고 애플리케이션이 내려갈 때 유실된다. 같은 풀로 옮겼다. 던져 놓고 잊는 성질은 그대로고 이제는 종료할 때 정리된다.

## 동작은 그대로

#29에서 박아 둔 테스트 13개가 손대기 전과 똑같이 통과한다. 알려진 결함도 그대로 남아 있다.

클린 빌드 통과. 전체 테스트 54개 통과.