### PR TITLE
fix: 이관 중에 미뤄 둔 결함 셋을 고친다

### DIFF
--- a/backend/src/main/java/com/joying/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/joying/chat/repository/ChatMessageRepository.java
@@ -32,6 +32,14 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
 	long countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfter(Long chatRoomId, Instant after);
 
 	/**
+	 * 이 사람이 보내지 않은 메시지 수.
+	 *
+	 * <p>한 번도 읽은 적이 없을 때 쓴다. 그때는 기준 시각이 없으므로 방의 처음부터
+	 * 전부 센다.
+	 */
+	long countByChatRoomIdAndIsDeletedFalseAndSenderIdNot(Long chatRoomId, Long excludeSenderId);
+
+	/**
 	 * 이 시각 이후, 이 사람이 보내지 않은 메시지 수.
 	 *
 	 * <p>안읽음을 셀 때 본인이 보낸 것은 빼야 한다.

--- a/backend/src/main/java/com/joying/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/joying/chat/service/ChatMessageService.java
@@ -38,19 +38,16 @@ public class ChatMessageService {
 	private final ChatMessageRepository chatMessageRepository;
 	private final ChatRoomRepository chatRoomRepository;
 	private final RedisPubSubPublisher redisPubSubPublisher;
+	private final ChatRoomPermissionCache permissionCache;
 
 	/**
 	 * 이 방을 볼 수 있는 사람인지.
 	 *
-	 * <p>구매자와 판매자만 본다. 나갔는지는 여기서 보지 않는다.
+	 * <p>보내는 경로와 같은 판정을 쓴다. 예전에는 여기서 구매자와 판매자인지만 보고
+	 * 나갔는지를 보지 않아, 나간 사람이 히스토리를 계속 읽을 수 있었다.
 	 */
 	private void validateChatRoomAccess(Long chatRoomId, Long memberId) {
-		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-			.orElseThrow(() -> new BusinessException(
-				ErrorCode.RESOURCE_NOT_FOUND, "채팅방을 찾을 수 없습니다"));
-
-		if (!memberId.equals(chatRoom.getBuyer().getMemberId())
-			&& !memberId.equals(chatRoom.getSeller().getMemberId())) {
+		if (!permissionCache.hasPermission(chatRoomId, memberId)) {
 			throw new BusinessException(ErrorCode.FORBIDDEN, "채팅방 접근 권한이 없습니다");
 		}
 	}

--- a/backend/src/main/java/com/joying/chat/service/ChatRoomPermissionCache.java
+++ b/backend/src/main/java/com/joying/chat/service/ChatRoomPermissionCache.java
@@ -10,6 +10,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import com.joying.chat.domain.ChatRoom;
+import com.joying.chat.domain.ChatRoomStatus;
+import com.joying.chat.repository.ChatRoomMemberRepository;
 import com.joying.chat.repository.ChatRoomRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -17,13 +19,12 @@ import lombok.RequiredArgsConstructor;
 /**
  * 채팅방에 들어갈 수 있는지를 Redis에 캐싱한다.
  *
- * <p>판정 근거는 이 사람이 방의 구매자이거나 판매자인가 하나뿐이다. 방을 나갔는지
- * ({@code isLeft})도, 방이 닫혔는지({@code status})도 보지 않는다. 그래서 나가기에서
- * 캐시를 지워도 다음 조회가 같은 근거로 다시 허용을 계산해 캐싱한다. 무효화가 결과를
- * 바꿀 수 없다는 뜻이다.
+ * <p>세 가지를 본다. 방의 구매자이거나 판매자인가, 아직 나가지 않았는가, 방이 열려
+ * 있는가.
  *
- * <p>나간 사람을 실제로 막는 것은 이 캐시가 아니라 메시지 전송 경로의 별도 조회다.
- * 이것은 이관 중에 고치지 않는다. 지금 동작은 테스트로 박아 두었다.
+ * <p>예전에는 첫째만 봤다. 그래서 나가기에서 캐시를 지워도 다음 조회가 같은 근거로
+ * 다시 허용을 계산해 캐싱했다. 무효화가 결과를 바꿀 수 없다는 뜻이었고, 나간 사람이
+ * 히스토리를 계속 읽을 수 있었다.
  */
 @Service
 @RequiredArgsConstructor
@@ -38,6 +39,7 @@ public class ChatRoomPermissionCache {
 
 	private final RedisTemplate<String, String> redis;
 	private final ChatRoomRepository chatRoomRepository;
+	private final ChatRoomMemberRepository chatRoomMemberRepository;
 
 	private String getKey(Long chatRoomId, Long memberId) {
 		return PERMISSION_KEY_PREFIX + chatRoomId + ":" + memberId;
@@ -64,12 +66,28 @@ public class ChatRoomPermissionCache {
 		if (chatRoom == null) {
 			return false;
 		}
-		return memberId.equals(chatRoom.getBuyer().getMemberId())
+
+		boolean isParticipant = memberId.equals(chatRoom.getBuyer().getMemberId())
 			|| memberId.equals(chatRoom.getSeller().getMemberId());
+		if (!isParticipant) {
+			return false;
+		}
+
+		// 닫힌 방은 누구에게도 열지 않는다
+		if (chatRoom.getStatus() != ChatRoomStatus.ACTIVE) {
+			return false;
+		}
+
+		// 나갔으면 다시 들어오기 전까지 막는다. 기록이 없어도 막는다.
+		return chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId)
+			.map(member -> !member.isLeft())
+			.orElse(false);
 	}
 
 	/**
 	 * 방을 만들 때 양쪽 권한을 미리 넣어 둔다. 첫 메시지에서 조회가 나가지 않는다.
+	 *
+	 * <p>막 만든 방이라 둘 다 남아 있고 열려 있다. 그래서 여기서는 다시 확인하지 않는다.
 	 */
 	public void warmupPermissions(Long chatRoomId) {
 		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null);

--- a/backend/src/main/java/com/joying/chat/service/ChatRoomService.java
+++ b/backend/src/main/java/com/joying/chat/service/ChatRoomService.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -294,8 +295,11 @@ public class ChatRoomService {
 	/**
 	 * 오래 안 쓴 방을 닫는다.
 	 *
-	 * <p>부르는 곳이 없다. 주기적으로 돌리려면 스케줄에 걸어야 한다.
+	 * <p>선언만 되어 있고 부르는 곳이 없어 한 번도 실행되지 않던 경로다. 하루에 한 번
+	 * 돌게 걸었다. 사람이 몰리지 않는 시각에 둔 이유는 방마다 시스템 메시지를 저장하고
+	 * 양쪽에 알림을 보내기 때문이다.
 	 */
+	@Scheduled(cron = "${joying.chat.auto-close.cron:0 30 4 * * *}", zone = "Asia/Seoul")
 	@Transactional
 	public void autoCloseInactiveChatRooms() {
 		Instant threshold = Instant.now().minusSeconds(AUTO_CLOSE_AFTER_SECONDS);

--- a/backend/src/main/java/com/joying/chat/service/UnreadCountService.java
+++ b/backend/src/main/java/com/joying/chat/service/UnreadCountService.java
@@ -155,9 +155,9 @@ public class UnreadCountService {
 	/**
 	 * 저장소에서 세어 Redis에 다시 넣는다.
 	 *
-	 * <p>한 번도 방을 열지 않아 읽은 시각이 없으면 0으로 본다. 쌓인 메시지가 있어도
-	 * 배지에 안 나온다는 뜻이라 옳지 않지만, 이관 중에 고치지 않는다. 지금 동작은
-	 * 테스트로 박아 두었다.
+	 * <p>읽은 시각이 없다는 것은 한 번도 안 읽었다는 뜻이지 읽을 것이 없다는 뜻이
+	 * 아니다. 그때는 방의 처음부터 전부 센다. 예전에는 여기서 0을 돌려줬고, 그래서
+	 * 새로 만든 방에 상대가 먼저 말을 걸면 배지에 아무것도 안 떴다.
 	 */
 	private long warmup(Long chatRoomId, Long memberId) {
 		try {
@@ -170,13 +170,13 @@ public class UnreadCountService {
 				return 0L;
 			}
 
-			long actualCount = 0L;
-			if (member.getLastReadAt() != null) {
-				// 본인이 보낸 것은 빼고 센다
-				actualCount = chatMessageRepository
+			// 본인이 보낸 것은 어느 쪽이든 빼고 센다
+			long actualCount = member.getLastReadAt() == null
+				? chatMessageRepository
+					.countByChatRoomIdAndIsDeletedFalseAndSenderIdNot(chatRoomId, memberId)
+				: chatMessageRepository
 					.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(
 						chatRoomId, member.getLastReadAt(), memberId);
-			}
 
 			try {
 				redis.opsForValue().set(getKey(chatRoomId, memberId),

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -193,6 +193,9 @@ joying.escrow.release-confirmation.interval-ms=${ESCROW_RELEASE_CONFIRMATION_INT
 # 매일 장부를 검산하는 시각
 joying.escrow.reconciliation.cron=${ESCROW_RECONCILIATION_CRON:0 10 4 * * *}
 
+# 오래 안 쓴 채팅방을 닫는 시각
+joying.chat.auto-close.cron=${CHAT_AUTO_CLOSE_CRON:0 30 4 * * *}
+
 # 미확정 적립을 다시 물어 확정하는 주기 (외부 금융망 구현일 때만 돈다)
 joying.escrow.deposit-recovery.interval-ms=${ESCROW_DEPOSIT_RECOVERY_INTERVAL_MS:60000}
 

--- a/backend/src/test/java/com/joying/chat/service/ChatRoomPermissionCacheTest.java
+++ b/backend/src/test/java/com/joying/chat/service/ChatRoomPermissionCacheTest.java
@@ -24,6 +24,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import com.joying.chat.domain.ChatRoom;
+import com.joying.chat.domain.ChatRoomMember;
+import com.joying.chat.domain.ChatRoomStatus;
+import com.joying.chat.repository.ChatRoomMemberRepository;
 import com.joying.chat.repository.ChatRoomRepository;
 import com.joying.member.domain.Member;
 
@@ -51,12 +54,31 @@ class ChatRoomPermissionCacheTest {
 	@Mock
 	ChatRoomRepository chatRoomRepository;
 
+	@Mock
+	ChatRoomMemberRepository chatRoomMemberRepository;
+
 	ChatRoomPermissionCache cache;
 
 	@BeforeEach
 	void setUp() {
 		given(redis.opsForValue()).willReturn(valueOps);
-		cache = new ChatRoomPermissionCache(redis, chatRoomRepository);
+		cache = new ChatRoomPermissionCache(redis, chatRoomRepository, chatRoomMemberRepository);
+	}
+
+	/** 방에 남아 있는 참여자 */
+	private void memberStaying(long memberId) {
+		ChatRoomMember member = mock(ChatRoomMember.class);
+		given(member.isLeft()).willReturn(false);
+		given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(ROOM_ID, memberId))
+			.willReturn(Optional.of(member));
+	}
+
+	/** 방을 나간 참여자 */
+	private void memberLeft(long memberId) {
+		ChatRoomMember member = mock(ChatRoomMember.class);
+		given(member.isLeft()).willReturn(true);
+		given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(ROOM_ID, memberId))
+			.willReturn(Optional.of(member));
 	}
 
 	private String key(long memberId) {
@@ -72,6 +94,7 @@ class ChatRoomPermissionCacheTest {
 		ChatRoom room = mock(ChatRoom.class);
 		given(room.getBuyer()).willReturn(buyer);
 		given(room.getSeller()).willReturn(seller);
+		given(room.getStatus()).willReturn(ChatRoomStatus.ACTIVE);
 		return room;
 	}
 
@@ -99,6 +122,7 @@ class ChatRoomPermissionCacheTest {
 		ChatRoom room = roomWith(BUYER_ID, SELLER_ID);
 		given(valueOps.get(key(BUYER_ID))).willReturn(null);
 		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		memberStaying(BUYER_ID);
 
 		assertThat(cache.hasPermission(ROOM_ID, BUYER_ID)).isTrue();
 		verify(valueOps).set(eq(key(BUYER_ID)), eq("ALLOWED"), anyLong(), eq(TimeUnit.HOURS));
@@ -125,24 +149,40 @@ class ChatRoomPermissionCacheTest {
 	}
 
 	@Test
-	@DisplayName("알려진 결함: 판정 근거가 buyer/seller뿐이라 방을 나갔는지는 보지 않는다")
-	void knownDefectIgnoresWhetherMemberLeft() {
-		// 판정은 방의 구매자나 판매자와 같은 사람인가만 본다. 나갔는지도, 방이
-		// 닫혔는지도 보지 않는다.
-		//
-		// 그래서 나가기에서 캐시를 지워도 다음 조회가 같은 근거로 다시 허용을
-		// 계산해 캐싱한다. 무효화가 결과를 바꿀 수 없다는 뜻이다.
-		//
-		// 나간 사람을 실제로 막는 것은 이 캐시가 아니라 메시지 전송 경로의 별도
-		// 조회다. 조회 경로에는 그 검사가 없어 히스토리가 열려 있다.
-		//
-		// 이관 중에 고치지 않는다. 지금 동작을 박아 두고 이관이 끝난 뒤 뒤집는다.
+	@DisplayName("방을 나간 사람은 거절한다. 무효화가 결과를 바꿀 수 있어야 한다")
+	void deniesMemberWhoLeft() {
+		// 예전에는 방의 구매자이거나 판매자인가만 봤다. 그래서 나가기에서 캐시를
+		// 지워도 다음 조회가 같은 근거로 다시 허용을 계산해 캐싱했다. 무효화가
+		// 결과를 바꿀 수 없다는 뜻이었다.
 		ChatRoom room = roomWith(BUYER_ID, SELLER_ID);
 		given(valueOps.get(key(BUYER_ID))).willReturn(null);
 		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		memberLeft(BUYER_ID);
 
-		assertThat(cache.hasPermission(ROOM_ID, BUYER_ID))
-			.as("나갔더라도 구매자이면 통과한다")
-			.isTrue();
+		assertThat(cache.hasPermission(ROOM_ID, BUYER_ID)).isFalse();
+		verify(valueOps).set(eq(key(BUYER_ID)), eq("DENIED"), anyLong(), eq(TimeUnit.HOURS));
+	}
+
+	@Test
+	@DisplayName("참여자 기록이 없으면 거절한다")
+	void deniesWhenNoMembershipRecord() {
+		ChatRoom room = roomWith(BUYER_ID, SELLER_ID);
+		given(valueOps.get(key(BUYER_ID))).willReturn(null);
+		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+		given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(ROOM_ID, BUYER_ID))
+			.willReturn(Optional.empty());
+
+		assertThat(cache.hasPermission(ROOM_ID, BUYER_ID)).isFalse();
+	}
+
+	@Test
+	@DisplayName("닫힌 방은 거절한다")
+	void deniesClosedRoom() {
+		ChatRoom room = roomWith(BUYER_ID, SELLER_ID);
+		given(room.getStatus()).willReturn(ChatRoomStatus.CLOSED);
+		given(valueOps.get(key(BUYER_ID))).willReturn(null);
+		given(chatRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+
+		assertThat(cache.hasPermission(ROOM_ID, BUYER_ID)).isFalse();
 	}
 }

--- a/backend/src/test/java/com/joying/chat/service/UnreadCountServiceTest.java
+++ b/backend/src/test/java/com/joying/chat/service/UnreadCountServiceTest.java
@@ -126,22 +126,20 @@ class UnreadCountServiceTest {
 	}
 
 	@Test
-	@DisplayName("알려진 결함: 방을 한 번도 안 열었으면 쌓인 메시지가 있어도 0으로 본다")
-	void knownDefectZeroWhenNeverOpened() {
-		// 읽은 시각이 없으면 저장소를 보지 않고 0을 돌려준다. 방을 한 번도 안 연
-		// 사람은 메시지가 아무리 쌓여도 배지가 0으로 보인다.
-		//
-		// 이관 중에 고치지 않는다. 지금 동작을 그대로 박아 두고, 이관이 끝난 뒤에
-		// 이 테스트를 뒤집으면서 고친다.
+	@DisplayName("방을 한 번도 안 열었으면 지워지지 않은 상대 메시지를 전부 센다")
+	void countsAllFromOthersWhenNeverOpened() {
+		// 읽은 시각이 없다는 것은 한 번도 안 읽었다는 뜻이지 읽을 것이 없다는 뜻이
+		// 아니다. 예전에는 여기서 저장소를 보지 않고 0을 돌려줬고, 그래서 새로 만든
+		// 방에 상대가 먼저 말을 걸면 배지에 아무것도 안 떴다.
 		ChatRoomMember member = org.mockito.Mockito.mock(ChatRoomMember.class);
 		given(member.getLastReadAt()).willReturn(null);
 
 		given(valueOps.get(KEY)).willReturn(null);
 		given(memberRepository.findByChatRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
 			.willReturn(Optional.of(member));
+		given(messageRepository.countByChatRoomIdAndIsDeletedFalseAndSenderIdNot(
+			ROOM_ID, MEMBER_ID)).willReturn(5L);
 
-		assertThat(service.get(ROOM_ID, MEMBER_ID)).isZero();
-		verify(messageRepository, never())
-			.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(any(), any(), any());
+		assertThat(service.get(ROOM_ID, MEMBER_ID)).isEqualTo(5L);
 	}
 }


### PR DESCRIPTION
Closes #37
Base: #36

이관 중에는 동작을 바꾸지 않기로 했다. 고치면 무엇이 원래 동작이었는지 알 수 없게 되기 때문이다. 이관이 끝났으므로 이제 고친다.

**각 결함마다 테스트를 먼저 뒤집어 빨간불을 보고 나서 고쳤다.** 그래야 그 테스트가 정말 그 결함을 잡는지 알 수 있다.

## 1. 한 번도 방을 안 열면 안읽음이 0으로 보였다

읽은 시각이 없다는 것은 **한 번도 안 읽었다**는 뜻이지 읽을 것이 없다는 뜻이 아니다. 그때는 방의 처음부터 전부 센다.

예전에는 0을 돌려줬고, 그래서 **새로 만든 방에 상대가 먼저 말을 걸면 배지에 아무것도 안 떴다.**

## 2. 권한 판정이 나갔는지를 보지 않았다

방의 구매자이거나 판매자인가만 봤다. 그래서 나가기에서 캐시를 지워도 다음 조회가 같은 근거로 다시 허용을 계산해 캐싱했다. **무효화가 결과를 바꿀 수 없다는 뜻이었다.**

| | 전 | 후 |
|---|---|---|
| 참여자인가 | 본다 | 본다 |
| 나갔는가 | 안 본다 | 본다 |
| 방이 열려 있는가 | 안 본다 | 본다 |

## 3. 조회 경로가 그 판정을 안 썼다

나간 사람을 실제로 막는 것은 캐시가 아니라 메시지 **전송** 경로의 별도 조회였다. **조회 경로에는 그 검사가 없어 나간 사람이 히스토리를 계속 읽을 수 있었다.** 두 경로가 같은 판정을 쓰게 했다.

## 4. 자동 종료가 한 번도 실행되지 않았다

30일 미사용 방을 닫는 메서드에 호출자가 없었다. 하루에 한 번 돌게 걸었다. 방마다 시스템 메시지를 저장하고 양쪽에 알림을 보내므로 사람이 몰리지 않는 시각에 뒀다.

## 확인

클린 빌드 통과. 전체 테스트 56개 통과 (신규 2개).