### PR TITLE
fix: 웹소켓 인증 누수와 구독 인가 구멍을 막는다

### DIFF
--- a/backend/src/main/java/com/joying/chat/config/WebSocketAuthInterceptor.java
+++ b/backend/src/main/java/com/joying/chat/config/WebSocketAuthInterceptor.java
@@ -1,6 +1,9 @@
 package com.joying.chat.config;
 
+import java.security.Principal;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,18 +14,29 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import com.joying.chat.service.ChatRoomPermissionCache;
 import com.joying.common.config.security.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
 
 /**
- * 웹소켓 연결에 붙는 인증.
+ * 웹소켓 연결에 붙는 인증과 인가.
  *
  * <p>연결을 맺을 때 쿠키에서 토큰을 꺼내 확인한다. REST와 같은 방식이라 브라우저가
  * 따로 무엇을 더 붙이지 않아도 된다.
+ *
+ * <p>두 가지를 뒤늦게 붙였다.
+ *
+ * <ul>
+ *   <li>처리가 끝나면 인증을 비운다. 인바운드 채널은 스레드 풀이라, 심어 두고
+ *       비우지 않으면 그 스레드를 다시 쓰는 다음 메시지가 남의 인증을 본다.
+ *   <li>구독할 때도 확인한다. 예전에는 연결만 봤고, 그래서 인증만 된 아무나
+ *       남의 방 타이핑과 읽음을 구독해 관찰할 수 있었다.
+ * </ul>
  */
 @Component
 @RequiredArgsConstructor
@@ -33,7 +47,11 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 	private static final String COOKIE_HEADER = "cookie";
 	private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
 
+	/** {@code /topic/chat/{roomId}/...} 에서 방 번호를 꺼낸다 */
+	private static final Pattern ROOM_DESTINATION = Pattern.compile("^/topic/chat/(\\d+)(/.*)?$");
+
 	private final JwtTokenProvider jwtTokenProvider;
+	private final ChatRoomPermissionCache permissionCache;
 
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -43,7 +61,11 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 			return message;
 		}
 
-		// 연결을 맺을 때만 확인한다
+		if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+			return canSubscribe(accessor) ? message : null;
+		}
+
+		// 연결을 맺을 때만 인증한다
 		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
 			try {
 				String token = extractTokenFromCookie(accessor);
@@ -70,6 +92,56 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 		}
 
 		return message;
+	}
+
+	/**
+	 * 처리가 끝나면 인증을 비운다.
+	 *
+	 * <p>이 채널은 스레드 풀이다. 비우지 않으면 심어 둔 인증이 스레드에 남고, 그
+	 * 스레드를 다시 쓰는 다음 메시지가 남의 인증을 본다. 눈으로는 안 보이고 부하가
+	 * 있어야 드러난다.
+	 */
+	@Override
+	public void afterSendCompletion(Message<?> message, MessageChannel channel,
+									boolean sent, Exception ex) {
+		SecurityContextHolder.clearContext();
+	}
+
+	/**
+	 * 이 방을 구독할 수 있는 사람인지.
+	 *
+	 * <p>방과 상관없는 목적지는 그대로 통과시킨다. 개인 큐는 목적지에 이미 사용자가
+	 * 들어 있어 남의 것을 구독할 수 없다.
+	 */
+	private boolean canSubscribe(StompHeaderAccessor accessor) {
+		String destination = accessor.getDestination();
+		if (destination == null) {
+			return true;
+		}
+
+		Matcher matcher = ROOM_DESTINATION.matcher(destination);
+		if (!matcher.matches()) {
+			return true;
+		}
+
+		Principal principal = accessor.getUser();
+		if (principal == null) {
+			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+			if (authentication == null) {
+				log.warn("인증 없이 구독 시도: destination={}", destination);
+				return false;
+			}
+			principal = authentication;
+		}
+
+		long chatRoomId = Long.parseLong(matcher.group(1));
+		long memberId = Long.parseLong(principal.getName());
+
+		boolean allowed = permissionCache.hasPermission(chatRoomId, memberId);
+		if (!allowed) {
+			log.warn("권한 없는 구독 차단: destination={}, memberId={}", destination, memberId);
+		}
+		return allowed;
 	}
 
 	/**

--- a/backend/src/test/java/com/joying/chat/config/WebSocketAuthInterceptorTest.java
+++ b/backend/src/test/java/com/joying/chat/config/WebSocketAuthInterceptorTest.java
@@ -1,0 +1,188 @@
+package com.joying.chat.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ExecutorSubscribableChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.joying.chat.service.ChatRoomPermissionCache;
+import com.joying.common.config.security.JwtTokenProvider;
+
+/**
+ * 웹소켓 인증이 스레드에 남는지, 구독이 인가를 받는지 잰다.
+ *
+ * <p>인바운드 채널은 스레드 풀이다. 인증을 심고 비우지 않으면 그 스레드가 다음
+ * 메시지를 처리할 때 남의 인증을 본다. 눈으로는 안 보이고 부하가 있어야 드러난다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class WebSocketAuthInterceptorTest {
+
+	@Mock
+	JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	ChatRoomPermissionCache permissionCache;
+
+	WebSocketAuthInterceptor interceptor;
+	MessageChannel channel;
+
+	@BeforeEach
+	void setUp() {
+		channel = new ExecutorSubscribableChannel();
+		interceptor = new WebSocketAuthInterceptor(jwtTokenProvider, permissionCache);
+
+		given(jwtTokenProvider.validateToken(anyString())).willReturn(true);
+		given(permissionCache.hasPermission(anyLong(), anyLong())).willReturn(true);
+
+		// 토큰에서 회원 번호를 뽑는 규칙을 한 번만 걸어 둔다. 여러 스레드에서 각자
+		// 스터빙하면 Mockito가 깨진다.
+		given(jwtTokenProvider.getMemberId(anyString())).willAnswer(invocation -> {
+			String token = invocation.getArgument(0);
+			return Long.valueOf(token.substring("token-".length()));
+		});
+	}
+
+	@AfterEach
+	void clear() {
+		SecurityContextHolder.clearContext();
+	}
+
+	private Message<byte[]> connectAs(long memberId) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+		accessor.setNativeHeader("cookie", "access_token=token-" + memberId);
+		return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+	}
+
+	private Message<byte[]> subscribeTo(String destination) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+		accessor.setSessionId("session-1");
+		accessor.setSubscriptionId("sub-1");
+		accessor.setDestination(destination);
+		return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+	}
+
+	@Test
+	@DisplayName("연결이 끝나면 인증이 스레드에 남지 않는다")
+	void doesNotLeakAuthenticationToThread() {
+		Message<byte[]> connect = connectAs(100L);
+
+		interceptor.preSend(connect, channel);
+		// 처리가 끝난 것을 알린다. 실제 채널이 매 메시지마다 부르는 자리다.
+		interceptor.afterSendCompletion(connect, channel, true, null);
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication())
+			.as("비우지 않으면 이 스레드를 다시 쓰는 다음 메시지가 남의 인증을 본다")
+			.isNull();
+	}
+
+	@Test
+	@DisplayName("연결이 아닌 메시지는 앞사람의 인증을 보지 않는다")
+	void noCrossTalkAcrossPooledThreads() throws Exception {
+		// 누수는 연결할 때 드러나지 않는다. 연결은 매번 자기 인증을 새로 심기 때문이다.
+		// 드러나는 자리는 연결이 아닌 메시지다. 그것은 인증을 심지 않으므로, 그 스레드에
+		// 남아 있던 앞사람의 인증을 그대로 본다.
+		int rounds = 50;
+		// 스레드 하나로 묶어야 재사용이 확실히 일어난다
+		ExecutorService pool = Executors.newFixedThreadPool(1);
+
+		List<Callable<Long>> tasks = IntStream.range(0, rounds)
+			.<Callable<Long>>mapToObj(i -> () -> {
+				long memberId = 1000L + i;
+
+				// 앞사람이 연결한다
+				Message<byte[]> connect = connectAs(memberId);
+				interceptor.preSend(connect, channel);
+				interceptor.afterSendCompletion(connect, channel, true, null);
+
+				// 뒷사람이 같은 스레드로 연결이 아닌 메시지를 보낸다
+				StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+				accessor.setDestination("/app/chat/1/send");
+				Message<byte[]> send =
+					MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+				interceptor.preSend(send, channel);
+
+				Authentication leaked = SecurityContextHolder.getContext().getAuthentication();
+				interceptor.afterSendCompletion(send, channel, true, null);
+
+				// 앞사람의 인증이 보이면 1
+				return leaked == null ? 0L : 1L;
+			}).toList();
+
+		List<Future<Long>> results = pool.invokeAll(tasks);
+		pool.shutdown();
+		pool.awaitTermination(30, TimeUnit.SECONDS);
+
+		long leaked = 0;
+		for (Future<Long> result : results) {
+			leaked += result.get();
+		}
+
+		assertThat(leaked)
+			.as("%d건 중 앞사람 인증이 보인 건수", rounds)
+			.isZero();
+	}
+
+	@Test
+	@DisplayName("들어갈 수 없는 방은 구독도 막는다")
+	void blocksSubscriptionToForbiddenRoom() {
+		given(permissionCache.hasPermission(7L, 100L)).willReturn(false);
+		SecurityContextHolder.getContext().setAuthentication(
+			new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+				"100", null, List.of()));
+
+		Message<byte[]> subscribe = subscribeTo("/topic/chat/7/typing");
+
+		assertThat(interceptor.preSend(subscribe, channel))
+			.as("막지 않으면 남의 방에서 누가 타이핑하는지 관찰할 수 있다")
+			.isNull();
+	}
+
+	@Test
+	@DisplayName("들어갈 수 있는 방은 구독을 통과시킨다")
+	void allowsSubscriptionToOwnRoom() {
+		given(permissionCache.hasPermission(7L, 100L)).willReturn(true);
+		SecurityContextHolder.getContext().setAuthentication(
+			new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+				"100", null, List.of()));
+
+		assertThat(interceptor.preSend(subscribeTo("/topic/chat/7/read"), channel)).isNotNull();
+	}
+
+	@Test
+	@DisplayName("방과 상관없는 목적지는 그대로 통과시킨다")
+	void allowsNonRoomDestinations() {
+		SecurityContextHolder.getContext().setAuthentication(
+			new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+				"100", null, List.of()));
+
+		assertThat(interceptor.preSend(subscribeTo("/user/queue/notifications"), channel))
+			.isNotNull();
+	}
+}


### PR DESCRIPTION
Closes #39
Base: #38

## 인증이 스레드에 남았다

연결할 때 `SecurityContextHolder`에 인증을 심고 비우지 않았다. 인바운드 채널은 스레드 풀이라 심어 둔 인증이 그 스레드에 남는다. **연결이 아닌 메시지는 인증을 심지 않으므로 남아 있던 앞사람의 인증을 그대로 본다.**

| | 앞사람 인증이 보인 건수 |
|---|---|
| 고치기 전 | **50건 중 50건** |
| 고친 뒤 | 0건 |

조건: 스레드 하나. 앞사람이 연결한 뒤 뒷사람이 같은 스레드로 연결이 아닌 메시지를 보내는 것을 50번.

## 재현을 두 번 만들었다

처음 만든 실험은 연결을 여러 건 돌려 남의 인증이 보이는지 셌는데 **0건이 나왔다.** 연결은 매번 자기 인증을 새로 심으므로 덮어써서 누수가 드러나지 않는다.

**측정값이 0이라고 결함이 없는 것이 아니라, 재는 자리가 틀렸을 수 있다.** 드러나는 자리는 연결이 아닌 메시지였다.

## 구독이 인가를 받지 않았다

인터셉터가 `CONNECT`만 봤다. `SUBSCRIBE`는 통과했으므로 **인증만 된 아무나 남의 방 타이핑과 읽음을 구독해 관찰할 수 있었다.**

이제 방 목적지로 구독할 때 그 방에 들어갈 수 있는 사람인지 확인한다. 판정은 권한 캐시가 하므로 #38에서 고친 대로 나갔는지와 방이 열려 있는지까지 함께 본다.

방과 상관없는 목적지는 그대로 통과시킨다. 개인 큐는 목적지에 이미 사용자가 들어 있어 남의 것을 구독할 수 없다.

## 확인

클린 빌드 통과. 전체 테스트 61개 통과 (신규 5개).