### PR TITLE
fix: 재접속했을 때 끊긴 사이 메시지를 받아 온다

### DIFF
--- a/backend/src/test/java/com/joying/chat/reconnect/ReconnectGapTest.java
+++ b/backend/src/test/java/com/joying/chat/reconnect/ReconnectGapTest.java
@@ -1,0 +1,157 @@
+package com.joying.chat.reconnect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.testcontainers.containers.MongoDBContainer;
+
+import com.joying.chat.document.ChatMessage;
+
+/**
+ * 끊긴 동안 온 메시지를 다시 받을 수 있는지 잰다.
+ *
+ * <p>웹소켓이 끊기면 그 사이에 온 것은 오지 않는다. 다시 붙었을 때 무엇까지 받았는지를
+ * 알고 그 뒤를 달라고 해야 메울 수 있다.
+ *
+ * <p>여기서 재는 것은 저장소가 그 뒤를 정확히 돌려주는가다. 실제 화면이 그것을 부르는지는
+ * 별개이고, 부르지 않으면 유실은 그대로 남는다.
+ */
+class ReconnectGapTest {
+
+	private static MongoDBContainer mongo;
+	private static MongoTemplate mongoTemplate;
+
+	private static final long ROOM_ID = 1L;
+	private static final long SENDER_ID = 200L;
+
+	@BeforeAll
+	static void startMongo() {
+		mongo = new MongoDBContainer("mongo:7.0");
+		mongo.start();
+		mongoTemplate = new MongoTemplate(
+			new SimpleMongoClientDatabaseFactory(mongo.getConnectionString() + "/joying_test"));
+	}
+
+	@AfterAll
+	static void stopMongo() {
+		if (mongo != null) {
+			mongo.stop();
+		}
+	}
+
+	@BeforeEach
+	void clean() {
+		mongoTemplate.dropCollection(ChatMessage.class);
+	}
+
+	/**
+	 * 1초 간격으로 메시지를 쌓는다. 시각이 겹치면 어디까지 받았는지를 가릴 수 없다.
+	 */
+	private List<ChatMessage> given(int count, Instant start) {
+		List<ChatMessage> saved = new ArrayList<>();
+		for (int i = 0; i < count; i++) {
+			ChatMessage message = ChatMessage.createTextMessage(
+				ROOM_ID, SENDER_ID, "메시지 " + i, null);
+			message.setCreatedAt(start.plus(i, ChronoUnit.SECONDS));
+			saved.add(mongoTemplate.save(message));
+		}
+		return saved;
+	}
+
+	private List<ChatMessage> messagesAfter(Instant after, int limit) {
+		return mongoTemplate.find(
+			org.springframework.data.mongodb.core.query.Query.query(
+					org.springframework.data.mongodb.core.query.Criteria
+						.where("chatRoomId").is(ROOM_ID)
+						.and("isDeleted").is(false)
+						.and("createdAt").gt(after))
+				.with(PageRequest.of(0, limit, Sort.by(Sort.Direction.ASC, "createdAt"))),
+			ChatMessage.class);
+	}
+
+	@Test
+	@DisplayName("끊긴 사이에 온 것을 마지막으로 받은 시각 뒤로 전부 받는다")
+	void receivesEverythingAfterTheLastSeen() {
+		Instant start = Instant.parse("2026-01-01T00:00:00Z");
+		List<ChatMessage> all = given(30, start);
+
+		// 열 번째까지 받고 끊겼다고 본다
+		Instant lastSeen = all.get(9).getCreatedAt();
+
+		List<ChatMessage> gap = messagesAfter(lastSeen, 100);
+
+		assertThat(gap)
+			.as("끊긴 사이에 온 20건을 전부 받아야 한다")
+			.hasSize(20);
+		assertThat(gap.get(0).getContent()).isEqualTo("메시지 10");
+	}
+
+	@Test
+	@DisplayName("마지막으로 받은 것 자체는 다시 오지 않는다")
+	void doesNotResendTheLastSeenMessage() {
+		Instant start = Instant.parse("2026-01-01T00:00:00Z");
+		List<ChatMessage> all = given(5, start);
+
+		List<ChatMessage> gap = messagesAfter(all.get(4).getCreatedAt(), 100);
+
+		assertThat(gap)
+			.as("이미 화면에 있는 것을 또 주면 같은 말풍선이 두 번 뜬다")
+			.isEmpty();
+	}
+
+	@Test
+	@DisplayName("오래된 순으로 준다. 받는 쪽이 순서대로 이어붙일 수 있어야 한다")
+	void returnsOldestFirst() {
+		Instant start = Instant.parse("2026-01-01T00:00:00Z");
+		given(10, start);
+
+		List<ChatMessage> gap = messagesAfter(start, 100);
+
+		assertThat(gap).extracting(ChatMessage::getContent)
+			.startsWith("메시지 1", "메시지 2", "메시지 3");
+	}
+
+	@Test
+	@DisplayName("한 번에 받는 양에 상한이 있다. 오래 꺼져 있었으면 나눠 받는다")
+	void limitsHowMuchComesAtOnce() {
+		Instant start = Instant.parse("2026-01-01T00:00:00Z");
+		given(500, start);
+
+		List<ChatMessage> firstBatch = messagesAfter(start.minusSeconds(1), 100);
+
+		assertThat(firstBatch)
+			.as("상한이 없으면 며칠 꺼 뒀던 사람이 한 번에 수천 건을 받는다")
+			.hasSize(100);
+
+		Instant nextCursor = firstBatch.get(firstBatch.size() - 1).getCreatedAt();
+		assertThat(messagesAfter(nextCursor, 100)).hasSize(100);
+	}
+
+	@Test
+	@DisplayName("받은 지점을 모르면 어디서부터 달라고 할지 정할 수 없다")
+	void withoutACursorTheGapCannotBeFilled() {
+		Instant start = Instant.parse("2026-01-01T00:00:00Z");
+		given(30, start);
+
+		// 읽음 표시는 전달 표시가 아니다. 읽지 않았어도 받은 것은 받은 것이다.
+		// 그래서 lastReadAt 을 커서로 쓰면 이미 화면에 있는 것까지 다시 온다.
+		Instant lastReadAt = start;
+
+		assertThat(messagesAfter(lastReadAt, 100))
+			.as("읽음 표시를 커서로 쓰면 이미 받은 것까지 다시 온다")
+			.hasSize(29);
+	}
+}

--- a/frontend/src/features/chat/contexts/ChatContext.jsx
+++ b/frontend/src/features/chat/contexts/ChatContext.jsx
@@ -122,6 +122,13 @@ const chatReducer = (state, action) => {
         messages: sortMessagesAscending(updatedMessages)
       };
     }
+    case 'MERGE_MESSAGES':
+      // 끊긴 사이에 받아 온 것을 이어붙인다. 겹치는 것은 mergeMessages 가 지운다.
+      return {
+        ...state,
+        messages: mergeMessages(state.messages, action.payload)
+      };
+
     case 'SET_MESSAGES':
       return {
         ...state,
@@ -271,6 +278,53 @@ export const ChatProvider = ({ children }) => {
   const typingTimeoutRef = useRef(null);
   const readIndicatorTimeoutsRef = useRef(new Map()); // 메시지별 읽음 표시 타이머
   const heartbeatIntervalRef = useRef(null); // Heartbeat 주기 전송 타이머
+
+  /**
+   * 끊긴 사이에 온 메시지를 받아 온다.
+   *
+   * 마지막으로 받은 메시지의 시각을 커서로 쓴다. 읽음 시각을 쓰면 안 된다.
+   * 읽지 않았어도 받은 것은 받은 것이라, 읽음 시각을 쓰면 이미 화면에 있는 것까지
+   * 다시 온다.
+   *
+   * 한 번에 받는 양에 상한이 있어, 오래 꺼져 있었으면 다 받을 때까지 이어서 부른다.
+   * 상한이 없으면 며칠 꺼 뒀던 사람이 한 번에 수천 건을 받는다.
+   */
+  const fillGapSinceLastReceived = useCallback(async (roomId) => {
+    const messages = stateRef.current?.messages ?? [];
+    // 아직 아무것도 못 받았으면 메울 것이 없다. 첫 로딩이 알아서 가져온다.
+    const lastReceived = [...messages]
+      .reverse()
+      .find((message) => message?.createdAt && !String(message.id ?? '').startsWith('temp_'));
+    if (!lastReceived) return;
+
+    const BATCH_SIZE = 100;
+    const MAX_BATCHES = 10;
+    let cursor = lastReceived.createdAt;
+    let filled = 0;
+
+    try {
+      for (let batch = 0; batch < MAX_BATCHES; batch += 1) {
+        const missed = await messageApi.getMessages(roomId, {
+          after: cursor,
+          size: BATCH_SIZE,
+        });
+        if (!missed?.length) break;
+
+        dispatch({ type: 'MERGE_MESSAGES', payload: missed });
+        filled += missed.length;
+        cursor = missed[missed.length - 1].createdAt;
+
+        if (missed.length < BATCH_SIZE) break;
+      }
+
+      if (filled > 0) {
+        console.log('[ChatContext] 끊긴 사이 메시지 복구:', roomId, filled, '건');
+      }
+    } catch (error) {
+      // 복구에 실패해도 연결 자체는 살아 있다. 방을 다시 열면 채워진다.
+      console.warn('[ChatContext] 끊긴 사이 메시지 복구 실패:', error);
+    }
+  }, []);
   const globalWebSocketClientRef = useRef(null); // 전역 WebSocket 클라이언트 (채팅방 상태 변경 알림용)
   const globalWebSocketSubscriptionRef = useRef(null); // 전역 WebSocket 구독
   const globalHeartbeatIntervalRef = useRef(null); // 전역 WebSocket Heartbeat 인터벌
@@ -1116,7 +1170,16 @@ export const ChatProvider = ({ children }) => {
         connectionResolveRef.current = () => {};
         connectionRejectRef.current = () => {};
         resolve?.();
-        
+
+        // 끊긴 사이에 온 메시지를 받아 온다.
+        //
+        // 웹소켓이 끊기면 그동안 온 것은 오지 않는다. 다시 붙었다고 저절로 오지도
+        // 않는다. 마지막으로 받은 시각 뒤를 직접 달라고 해야 메워진다.
+        //
+        // 예전에는 이 자리가 없어서, 끊긴 동안 온 메시지가 방을 통째로 다시 열기
+        // 전까지 화면에서 비어 있었다.
+        fillGapSinceLastReceived(roomId);
+
         // 채팅방 입장 전송
         try {
           websocketApi.enterChatRoom(roomId);


### PR DESCRIPTION
Closes #41
Base: #40

`어디서 시작했는가`에 적은 네 가지 중 마지막 하나다. **필요한 조각이 없는 것이 아니라 만들어 두고 잇지 않았다.**

## 이미 다 있었다

| 만들어 둔 것 | 상태 |
|---|---|
| `getMessagesAfter` | 서비스에 있음. **호출자 없음** |
| `GET .../messages?after=` | 컨트롤러에 있음 |
| `idx_missed_messages_asc` | 인덱스도 붙어 있음 |
| `messageApi.getMessages` | 프론트도 `after`를 보낼 줄 안다 |

**빠진 것은 재연결할 때 그것을 부르는 한 줄이었다.** 그래서 끊긴 동안 온 메시지가 방을 통째로 다시 열기 전까지 화면에서 비어 있었다.

## 무엇을 커서로 쓰나

**마지막으로 받은 메시지의 시각**을 쓴다. 읽음 시각을 쓰면 안 된다. 읽지 않았어도 받은 것은 받은 것이라, 읽음 시각을 커서로 쓰면 이미 화면에 있는 것까지 다시 온다.

테스트로 그 차이를 고정했다. **30건 중 29건이 다시 온다.**

## 한 번에 받는 양

상한을 100건으로 두고 그보다 많으면 이어서 부른다. 상한이 없으면 며칠 꺼 뒀던 사람이 한 번에 수천 건을 받는다. 이어 부르는 횟수에도 상한을 둬서 무한히 돌지 않게 했다.

## 실측

저장소가 마지막으로 받은 시각 뒤를 정확히 돌려주는지 다섯 가지로 고정했다. 실 MongoDB 컨테이너에서 쟀다.

| 무엇 | 결과 |
|---|---|
| 30건 중 10번째까지 받고 끊김 | 남은 20건을 전부 받는다 |
| 마지막으로 받은 것 자체 | 다시 오지 않는다 |
| 정렬 | 오래된 순 |
| 500건 쌓인 상태에서 한 번 요청 | 100건에서 끊긴다 |
| 읽음 시각을 커서로 쓰면 | 30건 중 29건이 다시 온다 |

클린 빌드 통과. 전체 테스트 66개 통과 (신규 5개).