### PR TITLE
메시지 순서를 서버가 정하고, 같은 전송을 한 번만 저장한다

### DIFF
--- a/backend/src/main/java/com/joying/chat/controller/ChatMessageController.java
+++ b/backend/src/main/java/com/joying/chat/controller/ChatMessageController.java
@@ -1,11 +1,9 @@
 package com.joying.chat.controller;
 
-import java.time.Instant;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,15 +42,19 @@ public class ChatMessageController {
 	 * <p>{@code keyword}가 있으면 찾기다. 없으면 목록이고, 이때 {@code before}는 과거로
 	 * 거슬러 올라가는 것이고 {@code after}는 끊긴 사이에 놓친 것을 받는 것이다.
 	 * 방향이 반대라 둘을 함께 보낼 수 없다.
+	 *
+	 * <p>커서는 시각이 아니라 방 안의 메시지 번호다. 예전 화면이 시각을 그대로 보내면
+	 * 형식이 맞지 않아 400으로 떨어진다. 조용히 무시되어 엉뚱한 구간이 오는 것보다
+	 * 낫다고 봤다.
 	 */
 	@Operation(summary = "채팅 메시지 목록 조회 및 검색",
-		description = "keyword가 있으면 검색, 없으면 목록이다. before는 과거로, after는 놓친 것을 받는다. 둘을 함께 쓸 수 없다.")
+		description = "keyword가 있으면 검색, 없으면 목록이다. before/after는 메시지 번호이며, before는 과거로, after는 놓친 것을 받는다. 둘을 함께 쓸 수 없다.")
 	@GetMapping
 	public ResponseEntity<ApiResponse.SuccessBody<List<ChatMessageResponse>>> getMessages(
 		@PathVariable Long chatRoomId,
 		@RequestParam(required = false) String keyword,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant before,
-		@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant after,
+		@RequestParam(required = false) Long before,
+		@RequestParam(required = false) Long after,
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "20") int size) {
 

--- a/backend/src/main/java/com/joying/chat/document/ChatMessage.java
+++ b/backend/src/main/java/com/joying/chat/document/ChatMessage.java
@@ -27,7 +27,13 @@ import lombok.Setter;
 @Getter
 @Document(collection = "chat_messages")
 @CompoundIndexes({
-	@CompoundIndex(name = "idx_chat_room_id_created_at", def = "{'chatRoomId': 1, 'createdAt': -1}")
+	@CompoundIndex(name = "idx_chat_room_id_created_at", def = "{'chatRoomId': 1, 'createdAt': -1}"),
+	@CompoundIndex(name = "idx_chat_room_id_sequence", def = "{'chatRoomId': 1, 'sequence': -1}"),
+	// sparse 는 필드가 아예 없을 때만 건너뛴다. null 로 들어오면 걸려서 두 번째가
+	// 막힌다. 값이 문자열일 때만 제약을 걸도록 조건을 준다.
+	@CompoundIndex(name = "uk_chat_room_id_client_message_id",
+		def = "{'chatRoomId': 1, 'clientMessageId': 1}", unique = true,
+		partialFilter = "{'clientMessageId': {'$type': 'string'}}")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessage {
@@ -39,6 +45,19 @@ public class ChatMessage {
 	@Field("chatRoomId")
 	@Indexed
 	private Long chatRoomId;
+
+	/**
+	 * 방 안에서 늘어나는 번호.
+	 *
+	 * <p>순서를 정하는 근거다. 시각으로 정하면 저장 직전에 앱 서버가 찍는 값이라
+	 * 같은 사람이 연속으로 보낸 두 건이 풀에서 경합해 뒤집힌다. 서버가 늘면 시계
+	 * 차이까지 더해져 사람마다 다른 순서를 볼 수 있다.
+	 *
+	 * <p>이 번호는 방마다 하나씩 늘어나므로 누가 먼저 받았든 모두가 같은 순서를 본다.
+	 */
+	@Field("sequence")
+	@Setter
+	private Long sequence;
 
 	@Field("senderId")
 	@Indexed
@@ -65,6 +84,16 @@ public class ChatMessage {
 	@Field("replyToMessageId")
 	private String replyToMessageId;
 
+	/**
+	 * 보내는 쪽이 만든 전송 식별자.
+	 *
+	 * <p>같은 값으로 두 번 저장되지 않게 하는 열쇠다. 애플리케이션에서 먼저 조회해
+	 * 확인하면 동시에 들어온 두 요청이 둘 다 없다고 읽고 둘 다 넣는다. 그래서 판정을
+	 * 저장소의 유니크 제약에 맡긴다.
+	 */
+	@Field("clientMessageId")
+	private String clientMessageId;
+
 	@CreatedDate
 	@Field("createdAt")
 	@Setter
@@ -89,6 +118,11 @@ public class ChatMessage {
 	@Field("isRead")
 	@Setter
 	private boolean isRead;
+
+	public void assign(Long sequence, String clientMessageId) {
+		this.sequence = sequence;
+		this.clientMessageId = clientMessageId;
+	}
 
 	private ChatMessage(Long chatRoomId, Long senderId, MessageType type, String content) {
 		this.chatRoomId = chatRoomId;

--- a/backend/src/main/java/com/joying/chat/dto/ChatMessageResponse.java
+++ b/backend/src/main/java/com/joying/chat/dto/ChatMessageResponse.java
@@ -30,6 +30,23 @@ public class ChatMessageResponse {
 	private Long chatRoomId;
 	private Long senderId;
 
+	/**
+	 * 방 안에서의 순번.
+	 *
+	 * <p>화면은 이것으로 정렬하고, 더 읽어 올 때 커서로도 쓴다. 저장 시각은 화면에
+	 * 보여 주기 위한 것이지 순서를 정하는 값이 아니다.
+	 */
+	private Long sequence;
+
+	/**
+	 * 보낸 쪽이 이 전송에 붙인 값.
+	 *
+	 * <p>돌려보내야 화면이 미리 그려 둔 것과 이것을 같은 건으로 묶는다. 돌려보내지
+	 * 않으면 화면은 내용과 시각을 비교해 짐작해야 하고, 같은 말을 두 번 보냈을 때
+	 * 하나를 지운다.
+	 */
+	private String clientMessageId;
+
 	/** 받는 사람. 웹소켓으로 내보낼 대상을 고르는 데 쓴다 */
 	private Long receiverId;
 
@@ -96,6 +113,8 @@ public class ChatMessageResponse {
 
 		return ChatMessageResponse.builder()
 			.id(message.getId())
+			.sequence(message.getSequence())
+			.clientMessageId(message.getClientMessageId())
 			.chatRoomId(message.getChatRoomId())
 			.senderId(message.getSenderId())
 			.type(message.getType())

--- a/backend/src/main/java/com/joying/chat/dto/SendMessageRequest.java
+++ b/backend/src/main/java/com/joying/chat/dto/SendMessageRequest.java
@@ -31,4 +31,15 @@ public class SendMessageRequest {
 	private String fileName;
 	private Long fileSize;
 	private String replyToMessageId;
+
+	/**
+	 * 이 전송을 가리키는 값.
+	 *
+	 * <p>보내는 쪽이 만든다. 발행이 실패해 사용자가 다시 보내면 같은 값이 온다.
+	 * 저장에 유니크 제약이 걸려 있어 두 번째는 새 문서를 만들지 않는다.
+	 *
+	 * <p>비어 있을 수 있다. 예전 화면은 이 값을 보내지 않으므로, 없으면 멱등을
+	 * 걸지 않고 그대로 저장한다.
+	 */
+	private String clientMessageId;
 }

--- a/backend/src/main/java/com/joying/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/joying/chat/repository/ChatMessageRepository.java
@@ -17,16 +17,21 @@ import com.joying.chat.document.ChatMessage;
 @Repository
 public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
 
-	/** 방의 메시지를 최신순으로 */
-	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseOrderByCreatedAtDesc(
+	/**
+	 * 방의 메시지를 최신순으로.
+	 *
+	 * <p>정렬 기준은 저장 시각이 아니라 방 안에서 발급한 번호다. 같은 밀리초에 저장된
+	 * 두 건은 시각으로 순서를 정할 수 없어 읽을 때마다 자리가 바뀐다.
+	 */
+	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseOrderBySequenceDesc(
 		Long chatRoomId, Pageable pageable);
 
-	/** 커서 페이징. 이 시각 이전을 최신순으로 */
-	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndCreatedAtBeforeOrderByCreatedAtDesc(
-		Long chatRoomId, Instant before, Pageable pageable);
+	/** 커서 페이징. 이 번호보다 앞을 최신순으로 */
+	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndSequenceLessThanOrderBySequenceDesc(
+		Long chatRoomId, Long before, Pageable pageable);
 
 	/** 방의 가장 최근 메시지 하나 */
-	ChatMessage findFirstByChatRoomIdAndIsDeletedFalseOrderByCreatedAtDesc(Long chatRoomId);
+	ChatMessage findFirstByChatRoomIdAndIsDeletedFalseOrderBySequenceDesc(Long chatRoomId);
 
 	/** 이 시각 이후 메시지 수 */
 	long countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfter(Long chatRoomId, Instant after);
@@ -48,25 +53,33 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
 		Long chatRoomId, Instant after, Long excludeSenderId);
 
 	/** 방 안에서 내용으로 찾기 */
-	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndContentContainingOrderByCreatedAtDesc(
+	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndContentContainingOrderBySequenceDesc(
 		Long chatRoomId, String keyword, Pageable pageable);
 
 	/**
-	 * 이 시각 이후를 오래된 순으로.
+	 * 이 번호 이후를 오래된 순으로.
 	 *
 	 * <p>재접속했을 때 놓친 메시지를 받는 데 쓴다. 받는 쪽이 순서대로 이어붙일 수
 	 * 있어야 하므로 오름차순이다.
+	 *
+	 * <p>커서를 시각으로 잡으면 같은 밀리초에 저장된 메시지 하나가 조용히 빠진다.
+	 * {@code After}는 초과라서 커서와 시각이 같은 것은 걸리지 않는다.
 	 */
-	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterOrderByCreatedAtAsc(
-		Long chatRoomId, Instant after, Pageable pageable);
+	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanOrderBySequenceAsc(
+		Long chatRoomId, Long after, Pageable pageable);
 
-	/** 특정 메시지 앞뒤로 뛸 때 쓴다 */
-	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndCreatedAtBeforeOrderByCreatedAtAsc(
-		Long chatRoomId, Instant before, Pageable pageable);
+	/** 같은 전송이 이미 저장돼 있는지 */
+	java.util.Optional<ChatMessage> findByChatRoomIdAndClientMessageId(
+		Long chatRoomId, String clientMessageId);
 
-	/** 특정 메시지 앞뒤로 뛸 때 쓴다 */
-	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterOrderByCreatedAtDesc(
-		Long chatRoomId, Instant after, Pageable pageable);
+	/** 방에서 가장 큰 번호. 지운 것도 번호를 차지하므로 삭제 여부를 보지 않는다 */
+	ChatMessage findFirstByChatRoomIdOrderBySequenceDesc(Long chatRoomId);
+
+	/** 번호가 없는 메시지. 번호를 도입하기 전에 저장된 것들이다 */
+	List<ChatMessage> findBySequenceIsNullOrderByCreatedAtAsc(Pageable pageable);
+
+	/** 번호가 없는 메시지가 몇 건인지 */
+	long countBySequenceIsNull();
 
 	/** 방을 지울 때 메시지도 함께 지운다 */
 	long deleteByChatRoomId(Long chatRoomId);

--- a/backend/src/main/java/com/joying/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/joying/chat/service/ChatMessageService.java
@@ -33,7 +33,7 @@ public class ChatMessageService {
 
 	private static final Logger log = LoggerFactory.getLogger(ChatMessageService.class);
 
-	private static final String CREATED_AT = "createdAt";
+	private static final String SEQUENCE = "sequence";
 
 	private final ChatMessageRepository chatMessageRepository;
 	private final ChatRoomRepository chatRoomRepository;
@@ -54,7 +54,7 @@ public class ChatMessageService {
 
 	public List<ChatMessageResponse> getMessages(Long chatRoomId, int page, int size) {
 		return toResponses(chatMessageRepository
-			.findByChatRoomIdAndIsDeletedFalseOrderByCreatedAtDesc(chatRoomId, desc(page, size)));
+			.findByChatRoomIdAndIsDeletedFalseOrderBySequenceDesc(chatRoomId, desc(page, size)));
 	}
 
 	/**
@@ -63,9 +63,12 @@ public class ChatMessageService {
 	 * <p>{@code before}는 과거로 거슬러 올라가는 것이고 {@code after}는 끊긴 사이에
 	 * 놓친 것을 받는 것이다. 방향이 반대라 함께 쓸 수 없다. 정렬도 그래서 다르다.
 	 * 놓친 것은 받는 쪽이 순서대로 이어붙여야 하므로 오래된 순으로 준다.
+	 *
+	 * <p>커서는 방 안의 메시지 번호다. 시각을 커서로 쓰면 같은 밀리초에 저장된 것이
+	 * 경계에서 빠지거나 두 번 온다.
 	 */
-	public List<ChatMessageResponse> getMessagesBefore(Long chatRoomId, Instant before,
-													   Instant after, int size, Long memberId) {
+	public List<ChatMessageResponse> getMessagesBefore(Long chatRoomId, Long before,
+													   Long after, int size, Long memberId) {
 		validateChatRoomAccess(chatRoomId, memberId);
 
 		if (before != null && after != null) {
@@ -76,15 +79,15 @@ public class ChatMessageService {
 		List<ChatMessage> messages;
 		if (after != null) {
 			messages = chatMessageRepository
-				.findByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterOrderByCreatedAtAsc(
+				.findByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanOrderBySequenceAsc(
 					chatRoomId, after, asc(0, size));
 		} else if (before != null) {
 			messages = chatMessageRepository
-				.findByChatRoomIdAndIsDeletedFalseAndCreatedAtBeforeOrderByCreatedAtDesc(
+				.findByChatRoomIdAndIsDeletedFalseAndSequenceLessThanOrderBySequenceDesc(
 					chatRoomId, before, desc(0, size));
 		} else {
 			messages = chatMessageRepository
-				.findByChatRoomIdAndIsDeletedFalseOrderByCreatedAtDesc(chatRoomId, desc(0, size));
+				.findByChatRoomIdAndIsDeletedFalseOrderBySequenceDesc(chatRoomId, desc(0, size));
 		}
 
 		return toResponses(messages);
@@ -95,10 +98,17 @@ public class ChatMessageService {
 		validateChatRoomAccess(chatRoomId, memberId);
 
 		return toResponses(chatMessageRepository
-			.findByChatRoomIdAndIsDeletedFalseAndContentContainingOrderByCreatedAtDesc(
+			.findByChatRoomIdAndIsDeletedFalseAndContentContainingOrderBySequenceDesc(
 				chatRoomId, keyword, desc(page, size)));
 	}
 
+	/**
+	 * 안읽음 건수.
+	 *
+	 * <p>여기만 아직 시각으로 센다. 읽은 지점을 방 참여자에 시각으로 들고 있어서다.
+	 * 같은 밀리초 경계에서 한 건이 어긋날 수 있다. 순서와 달리 눈에 보이는 문제로
+	 * 이어지지 않아 이번에는 손대지 않았다.
+	 */
 	public long getUnreadCount(Long chatRoomId, Instant lastReadAt) {
 		if (lastReadAt == null) {
 			return 0L;
@@ -110,12 +120,12 @@ public class ChatMessageService {
 	/**
 	 * 끊긴 사이에 놓친 것을 받는다.
 	 */
-	public List<ChatMessageResponse> getMessagesAfter(Long chatRoomId, Instant after,
+	public List<ChatMessageResponse> getMessagesAfter(Long chatRoomId, Long after,
 													  int limit, Long memberId) {
 		validateChatRoomAccess(chatRoomId, memberId);
 
 		return toResponses(chatMessageRepository
-			.findByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterOrderByCreatedAtAsc(
+			.findByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanOrderBySequenceAsc(
 				chatRoomId, after, asc(0, limit)));
 	}
 
@@ -137,17 +147,17 @@ public class ChatMessageService {
 			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "해당 채팅방의 메시지가 아닙니다");
 		}
 
-		Instant targetTime = target.getCreatedAt();
-		if (targetTime == null) {
-			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "메시지 생성 시간이 없습니다");
+		Long targetSequence = target.getSequence();
+		if (targetSequence == null) {
+			throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "메시지 번호가 없습니다");
 		}
 
 		List<ChatMessage> all = new ArrayList<>();
 
 		if (before > 0) {
 			List<ChatMessage> beforeMessages = new ArrayList<>(chatMessageRepository
-				.findByChatRoomIdAndIsDeletedFalseAndCreatedAtBeforeOrderByCreatedAtDesc(
-					chatRoomId, targetTime, desc(0, before)));
+				.findByChatRoomIdAndIsDeletedFalseAndSequenceLessThanOrderBySequenceDesc(
+					chatRoomId, targetSequence, desc(0, before)));
 			// 최신순으로 받았으므로 시간순으로 뒤집는다
 			java.util.Collections.reverse(beforeMessages);
 			all.addAll(beforeMessages);
@@ -157,8 +167,8 @@ public class ChatMessageService {
 
 		if (after > 0) {
 			all.addAll(chatMessageRepository
-				.findByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterOrderByCreatedAtAsc(
-					chatRoomId, targetTime, asc(0, after)));
+				.findByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanOrderBySequenceAsc(
+					chatRoomId, targetSequence, asc(0, after)));
 		}
 
 		return toResponses(all);
@@ -277,10 +287,10 @@ public class ChatMessageService {
 	}
 
 	private Pageable desc(int page, int size) {
-		return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, CREATED_AT));
+		return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, SEQUENCE));
 	}
 
 	private Pageable asc(int page, int size) {
-		return PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, CREATED_AT));
+		return PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, SEQUENCE));
 	}
 }

--- a/backend/src/main/java/com/joying/chat/service/ChatService.java
+++ b/backend/src/main/java/com/joying/chat/service/ChatService.java
@@ -8,6 +8,7 @@ import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -57,6 +58,7 @@ public class ChatService {
 	private final ChatPresenceService chatPresenceService;
 	private final ChatBroadcaster chatBroadcaster;
 	private final MongoTemplate mongoTemplate;
+	private final MessageSequenceGenerator sequenceGenerator;
 
 	public ChatService(ChatRoomRepository chatRoomRepository,
 					   @Qualifier("chatQueryExecutor") Executor queryExecutor,
@@ -68,7 +70,8 @@ public class ChatService {
 					   WebPushService webPushService,
 					   ChatPresenceService chatPresenceService,
 					   ChatBroadcaster chatBroadcaster,
-					   MongoTemplate mongoTemplate) {
+					   MongoTemplate mongoTemplate,
+					   MessageSequenceGenerator sequenceGenerator) {
 		this.chatRoomRepository = chatRoomRepository;
 		this.queryExecutor = queryExecutor;
 		this.chatRoomMemberRepository = chatRoomMemberRepository;
@@ -80,6 +83,7 @@ public class ChatService {
 		this.chatPresenceService = chatPresenceService;
 		this.chatBroadcaster = chatBroadcaster;
 		this.mongoTemplate = mongoTemplate;
+		this.sequenceGenerator = sequenceGenerator;
 	}
 
 	public ChatMessageResponse sendMessage(Long chatRoomId, Long senderId,
@@ -107,10 +111,7 @@ public class ChatService {
 		requireNotLeft(chatRoomId, senderId, "나간 채팅방입니다. 먼저 재입장해주세요", ErrorCode.FORBIDDEN);
 		requireNotLeft(chatRoomId, receiverId, "상대방이 나간 채팅방입니다", ErrorCode.INVALID_INPUT_VALUE);
 
-		ChatMessage chatMessage = buildMessage(chatRoomId, senderId, request);
-		chatMessage.setCreatedAt(Instant.now());
-
-		ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+		ChatMessage savedMessage = saveOnce(chatRoomId, senderId, request);
 
 		ChatMessage replyMessage = savedMessage.getReplyToMessageId() == null ? null
 			: chatMessageRepository.findById(savedMessage.getReplyToMessageId()).orElse(null);
@@ -343,6 +344,44 @@ public class ChatService {
 			return (size / 1024) + " KB";
 		}
 		return (size / (1024 * 1024)) + " MB";
+	}
+
+	/**
+	 * 한 번만 저장한다.
+	 *
+	 * <p>같은 전송 식별자가 이미 있으면 그때 저장한 것을 그대로 돌려준다. 발행이
+	 * 실패해 사용자가 다시 보내도 문서가 두 개 생기지 않는다.
+	 *
+	 * <p>먼저 조회해 확인하는 것만으로는 부족하다. 동시에 들어온 두 요청이 둘 다
+	 * 없다고 읽고 둘 다 넣는다. 그래서 판정을 저장소의 유니크 제약에 맡기고, 걸리면
+	 * 그때 다시 읽는다.
+	 */
+	private ChatMessage saveOnce(Long chatRoomId, Long senderId, SendMessageRequest request) {
+		String clientMessageId = request.getClientMessageId();
+
+		if (clientMessageId != null) {
+			ChatMessage already = chatMessageRepository
+				.findByChatRoomIdAndClientMessageId(chatRoomId, clientMessageId).orElse(null);
+			if (already != null) {
+				log.info("이미 저장된 전송이다: chatRoomId={}, clientMessageId={}",
+					chatRoomId, clientMessageId);
+				return already;
+			}
+		}
+
+		ChatMessage chatMessage = buildMessage(chatRoomId, senderId, request);
+		chatMessage.setCreatedAt(Instant.now());
+		// 순서를 정하는 것은 시각이 아니라 이 번호다
+		chatMessage.assign(sequenceGenerator.next(chatRoomId), clientMessageId);
+
+		try {
+			return chatMessageRepository.save(chatMessage);
+		} catch (DuplicateKeyException e) {
+			// 같은 전송이 동시에 들어와 다른 쪽이 먼저 넣었다
+			return chatMessageRepository
+				.findByChatRoomIdAndClientMessageId(chatRoomId, clientMessageId)
+				.orElseThrow(() -> e);
+		}
 	}
 
 	/**

--- a/backend/src/main/java/com/joying/chat/service/MessageSequenceBackfill.java
+++ b/backend/src/main/java/com/joying/chat/service/MessageSequenceBackfill.java
@@ -1,0 +1,108 @@
+package com.joying.chat.service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import com.joying.chat.document.ChatMessage;
+import com.joying.chat.repository.ChatMessageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 번호를 도입하기 전에 저장된 메시지에 번호를 채운다.
+ *
+ * <p>정렬 기준을 시각에서 번호로 옮기면 번호가 없는 문서가 문제가 된다. MongoDB는
+ * 없는 값을 가장 작은 것으로 보므로 내림차순에서 맨 뒤로 밀린다. 새 메시지보다
+ * 뒤에 놓이는 것 자체는 맞지만, 번호가 없는 것들끼리는 순서를 정할 근거가 없어
+ * 읽을 때마다 자리가 바뀐다. 그래서 한 번 채워 둔다.
+ *
+ * <p>기준은 저장 시각이다. 이미 저장된 것에는 그것 말고 쓸 수 있는 순서가 없다.
+ * 같은 밀리초에 저장된 두 건의 앞뒤는 지금 와서 알 수 없고, 여기서 정한 순서가
+ * 그대로 굳는다. 앞으로 들어올 것을 바로잡는 것이 목적이지 지난 것을 복원하는
+ * 것이 목적은 아니다.
+ *
+ * <p>서버가 여러 대여도 한 번만 도는 장치는 두지 않았다. 두 대가 같은 문서를 집어도
+ * 둘 다 같은 시각순을 보고 같은 번호를 쓴다. 이 작업은 여러 번 돌아도 결과가 같다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MessageSequenceBackfill implements ApplicationRunner {
+
+	private static final Logger log = LoggerFactory.getLogger(MessageSequenceBackfill.class);
+
+	/** 한 번에 읽어 올 건수. 전부 메모리에 올리지 않기 위해 끊어 읽는다 */
+	private static final int BATCH_SIZE = 500;
+
+	/** 안전장치. 이만큼 돌고도 남으면 멈추고 로그로 알린다 */
+	private static final int MAX_BATCHES = 200;
+
+	private final ChatMessageRepository chatMessageRepository;
+	private final MessageSequenceGenerator sequenceGenerator;
+
+	@Override
+	public void run(ApplicationArguments args) {
+		long remaining = chatMessageRepository.countBySequenceIsNull();
+		if (remaining == 0) {
+			return;
+		}
+
+		log.info("메시지 번호 채우기 시작: 대상={}건", remaining);
+
+		// 방마다 지금까지 쓴 가장 큰 번호. 여기서 이어 붙인다
+		Map<Long, Long> nextByRoom = new LinkedHashMap<>();
+		long filled = 0;
+
+		for (int batch = 0; batch < MAX_BATCHES; batch++) {
+			List<ChatMessage> targets = chatMessageRepository
+				.findBySequenceIsNullOrderByCreatedAtAsc(PageRequest.of(0, BATCH_SIZE));
+			if (targets.isEmpty()) {
+				break;
+			}
+
+			List<ChatMessage> updated = new ArrayList<>(targets.size());
+			for (ChatMessage message : targets) {
+				Long roomId = message.getChatRoomId();
+				long next = nextByRoom.computeIfAbsent(roomId, this::currentMaxOf) + 1;
+				nextByRoom.put(roomId, next);
+				message.setSequence(next);
+				updated.add(message);
+			}
+
+			chatMessageRepository.saveAll(updated);
+			filled += updated.size();
+		}
+
+		// 새 메시지가 채운 번호 뒤에서 시작하도록 방마다 시작값을 올려 둔다
+		nextByRoom.forEach(sequenceGenerator::seedAtLeast);
+
+		long left = chatMessageRepository.countBySequenceIsNull();
+		if (left > 0) {
+			log.warn("메시지 번호 채우기 미완료: 채운 건수={}, 남은 건수={}", filled, left);
+			return;
+		}
+		log.info("메시지 번호 채우기 완료: 채운 건수={}, 방={}개", filled, nextByRoom.size());
+	}
+
+	/**
+	 * 이 방에서 지금까지 쓴 가장 큰 번호. 하나도 없으면 0.
+	 *
+	 * <p>지운 메시지도 번호를 차지하고 있으므로 삭제 여부를 보지 않는다. 걸렀다가는
+	 * 이미 쓴 번호를 다시 내주게 된다.
+	 */
+	private long currentMaxOf(Long chatRoomId) {
+		ChatMessage newest = chatMessageRepository.findFirstByChatRoomIdOrderBySequenceDesc(chatRoomId);
+		if (newest == null || newest.getSequence() == null) {
+			return 0L;
+		}
+		return newest.getSequence();
+	}
+}

--- a/backend/src/main/java/com/joying/chat/service/MessageSequenceGenerator.java
+++ b/backend/src/main/java/com/joying/chat/service/MessageSequenceGenerator.java
@@ -1,0 +1,81 @@
+package com.joying.chat.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 방 안에서 메시지에 붙일 번호를 발급한다.
+ *
+ * <p>Redis의 증가 연산 하나로 정한다. 여러 서버가 동시에 불러도 같은 번호가 두 번
+ * 나가지 않는다. 읽고 더해서 쓰는 방식이면 그 사이에 낀 요청이 같은 값을 받는다.
+ *
+ * <p>번호에 빈 자리가 생길 수 있다. 번호를 받은 뒤 저장이 실패하면 그 번호는 쓰이지
+ * 않는다. 순서를 정하는 것이 목적이지 몇 건인지 세는 것이 아니므로 빈 자리는 괜찮다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MessageSequenceGenerator {
+
+	private static final Logger log = LoggerFactory.getLogger(MessageSequenceGenerator.class);
+
+	private static final String SEQUENCE_KEY_PREFIX = "chat:sequence:";
+
+	/**
+	 * 지금 값이 주어진 값보다 작을 때만 올린다.
+	 *
+	 * <p>읽고 비교해서 쓰는 것을 세 번의 호출로 나누면 그 사이에 낀 발급이 지워진다.
+	 * 이미 나간 번호를 다시 내주게 되므로, 지금 고치고 있는 것과 같은 결함이 된다.
+	 * Redis가 스크립트 하나를 통째로 돌리는 것을 이용해 한 번에 끝낸다.
+	 */
+	private static final RedisScript<Long> RAISE_TO = new DefaultRedisScript<>("""
+		local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+		local floor = tonumber(ARGV[1])
+		if current < floor then
+		  redis.call('SET', KEYS[1], ARGV[1])
+		  return 1
+		end
+		return 0
+		""", Long.class);
+
+	private final RedisTemplate<String, String> redis;
+
+	/**
+	 * 다음 번호를 준다.
+	 *
+	 * <p>Redis가 죽으면 번호를 받을 수 없다. 그때는 저장을 막는다. 번호 없이 저장하면
+	 * 그 메시지만 순서를 정할 근거가 없어 화면에서 자리를 못 잡는다.
+	 */
+	public long next(Long chatRoomId) {
+		Long sequence = redis.opsForValue().increment(SEQUENCE_KEY_PREFIX + chatRoomId);
+		if (sequence == null) {
+			throw new IllegalStateException("메시지 번호를 받지 못했습니다: chatRoomId=" + chatRoomId);
+		}
+		return sequence;
+	}
+
+	/**
+	 * 이미 쌓인 방을 이어 받는다.
+	 *
+	 * <p>번호를 도입하기 전에 저장된 메시지에 번호를 채우고 나면, 다음 번호가 그보다
+	 * 커야 새 메시지가 뒤로 붙는다.
+	 *
+	 * <p>{@code setIfAbsent}로 걸지 않는 이유는 값이 이미 있을 수 있어서다. 채우기가
+	 * 도는 사이에 새 메시지가 들어와 값이 생겼다면 그것을 덮어써서는 안 되고, 채운
+	 * 번호보다 작다면 올려야 한다. 그래서 지금 값을 보고 작을 때만 올린다.
+	 */
+	public void seedAtLeast(Long chatRoomId, long floor) {
+		String key = SEQUENCE_KEY_PREFIX + chatRoomId;
+		Long raised = redis.execute(RAISE_TO, List.of(key), String.valueOf(floor));
+		if (raised != null && raised == 1L) {
+			log.info("메시지 번호 시작값 설정: chatRoomId={}, from={}", chatRoomId, floor);
+		}
+	}
+}

--- a/backend/src/test/java/com/joying/chat/ordering/MessageIdempotencyTest.java
+++ b/backend/src/test/java/com/joying/chat/ordering/MessageIdempotencyTest.java
@@ -1,0 +1,139 @@
+package com.joying.chat.ordering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.testcontainers.containers.MongoDBContainer;
+
+import com.joying.chat.document.ChatMessage;
+
+/**
+ * 같은 전송이 두 건이 되지 않는지 잰다.
+ *
+ * <p>발행이 실패하면 저장은 됐는데 전달이 안 된 상태가 된다. 사용자가 다시 보내면
+ * 예전에는 새 문서가 하나 더 생겼다.
+ *
+ * <p>판정을 애플리케이션 조회로 하면 동시에 들어온 두 요청이 둘 다 없다고 읽고 둘 다
+ * 넣는다. 그래서 저장소의 유니크 제약에 맡긴다. 여기서 재는 것이 그 성질이다.
+ */
+class MessageIdempotencyTest {
+
+	private static MongoDBContainer mongo;
+	private static MongoTemplate mongoTemplate;
+
+	private static final long ROOM_ID = 1L;
+	private static final long SENDER_ID = 100L;
+
+	private final AtomicLong sequence = new AtomicLong();
+
+	@BeforeAll
+	static void startMongo() {
+		mongo = new MongoDBContainer("mongo:7.0");
+		mongo.start();
+		mongoTemplate = new MongoTemplate(
+			new SimpleMongoClientDatabaseFactory(mongo.getConnectionString() + "/joying_test"));
+	}
+
+	@AfterAll
+	static void stopMongo() {
+		if (mongo != null) {
+			mongo.stop();
+		}
+	}
+
+	@BeforeEach
+	void clean() {
+		mongoTemplate.dropCollection(ChatMessage.class);
+		// 제약은 컬렉션을 새로 만들 때마다 다시 걸어야 한다
+		mongoTemplate.indexOps(ChatMessage.class).ensureIndex(
+			new org.springframework.data.mongodb.core.index.Index()
+				.on("chatRoomId", org.springframework.data.domain.Sort.Direction.ASC)
+				.on("clientMessageId", org.springframework.data.domain.Sort.Direction.ASC)
+				.named("uk_chat_room_id_client_message_id")
+				.unique()
+				// 값이 문자열일 때만 제약을 건다. sparse 는 null 을 걸러 주지 않는다.
+				.partial(org.springframework.data.mongodb.core.index.PartialIndexFilter.of(
+					Criteria.where("clientMessageId").type(2))));
+	}
+
+	private ChatMessage save(String clientMessageId) {
+		ChatMessage message = ChatMessage.createTextMessage(ROOM_ID, SENDER_ID, "안녕하세요", null);
+		message.setCreatedAt(Instant.now());
+		message.assign(sequence.incrementAndGet(), clientMessageId);
+		return mongoTemplate.save(message);
+	}
+
+	private long countInRoom() {
+		return mongoTemplate.count(Query.query(Criteria.where("chatRoomId").is(ROOM_ID)),
+			ChatMessage.class);
+	}
+
+	@Test
+	@DisplayName("같은 전송 식별자로 두 번 저장하면 두 번째가 막힌다")
+	void sameClientMessageIdIsRejected() {
+		save("send-1");
+
+		assertThat(catchDuplicate(() -> save("send-1")))
+			.as("막지 않으면 같은 말풍선이 두 번 뜬다")
+			.isTrue();
+		assertThat(countInRoom()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("같은 식별자가 동시에 들어와도 한 건만 남는다")
+	void concurrentSameIdKeepsOne() throws Exception {
+		int attempts = 16;
+		ExecutorService pool = Executors.newFixedThreadPool(attempts);
+
+		List<Callable<Boolean>> tasks = IntStream.range(0, attempts)
+			.<Callable<Boolean>>mapToObj(i -> () -> catchDuplicate(() -> save("send-same")))
+			.toList();
+
+		pool.invokeAll(tasks);
+		pool.shutdown();
+		pool.awaitTermination(30, TimeUnit.SECONDS);
+
+		System.out.println("[측정] 같은 식별자 " + attempts + "건 동시 저장 후 남은 문서 = "
+			+ countInRoom());
+		assertThat(countInRoom())
+			.as("애플리케이션 조회로 막으면 둘 다 없다고 읽고 둘 다 넣는다")
+			.isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("식별자가 없으면 멱등을 걸지 않고 그대로 저장한다")
+	void nullIdentifierIsNotDeduplicated() {
+		// 예전 화면은 이 값을 보내지 않는다. 그때는 막지 않고 그대로 넣는다.
+		save(null);
+		save(null);
+
+		assertThat(countInRoom()).isEqualTo(2);
+	}
+
+	private boolean catchDuplicate(Runnable task) {
+		try {
+			task.run();
+			return false;
+		} catch (DuplicateKeyException e) {
+			return true;
+		}
+	}
+}

--- a/backend/src/test/java/com/joying/chat/ordering/MessageOrderTest.java
+++ b/backend/src/test/java/com/joying/chat/ordering/MessageOrderTest.java
@@ -1,0 +1,184 @@
+package com.joying.chat.ordering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.testcontainers.containers.MongoDBContainer;
+
+import com.joying.chat.document.ChatMessage;
+
+/**
+ * 보낸 순서와 보이는 순서가 같은지 잰다.
+ *
+ * <p>지금 순서를 정하는 값은 앱 서버가 저장 직전에 찍는 시각 하나뿐이다. 인바운드마다
+ * 새 작업을 띄우므로, 같은 사람이 연속으로 보낸 두 건이 풀에서 경합한다. 먼저 도착한
+ * 쪽이 아니라 먼저 실행된 쪽이 이른 시각을 가져간다.
+ *
+ * <p>여기서는 그 경합을 그대로 재현한다. 웹소켓을 띄우지 않고, 시각을 찍고 저장하는
+ * 부분만 같은 모양으로 만들어 여러 스레드에서 돌린다.
+ */
+class MessageOrderTest {
+
+	private static MongoDBContainer mongo;
+	private static MongoTemplate mongoTemplate;
+
+	private static final long ROOM_ID = 1L;
+	private static final long SENDER_ID = 100L;
+
+	@BeforeAll
+	static void startMongo() {
+		mongo = new MongoDBContainer("mongo:7.0");
+		mongo.start();
+		mongoTemplate = new MongoTemplate(
+			new SimpleMongoClientDatabaseFactory(mongo.getConnectionString() + "/joying_test"));
+	}
+
+	@AfterAll
+	static void stopMongo() {
+		if (mongo != null) {
+			mongo.stop();
+		}
+	}
+
+	@BeforeEach
+	void clean() {
+		mongoTemplate.dropCollection(ChatMessage.class);
+	}
+
+	/**
+	 * 보낸 순서대로 번호를 매겨 저장한다. 시각은 저장 직전에 찍는다. 지금 코드와 같다.
+	 */
+	private void sendConcurrently(int count, int threads) throws Exception {
+		ExecutorService pool = Executors.newFixedThreadPool(threads);
+		List<Callable<Void>> tasks = IntStream.range(0, count)
+			.<Callable<Void>>mapToObj(i -> () -> {
+				ChatMessage message = ChatMessage.createTextMessage(
+					ROOM_ID, SENDER_ID, String.valueOf(i), null);
+				message.setCreatedAt(Instant.now());
+				mongoTemplate.save(message);
+				return null;
+			}).toList();
+
+		pool.invokeAll(tasks);
+		pool.shutdown();
+		pool.awaitTermination(30, TimeUnit.SECONDS);
+	}
+
+	/**
+	 * 브라우저가 하는 것과 같이 시각으로 정렬한 뒤, 보낸 번호가 오름차순인지 센다.
+	 *
+	 * @return 앞엣것보다 작은 번호가 나온 횟수
+	 */
+	private long inversionsWhenSortedByTime() {
+		List<ChatMessage> messages = new ArrayList<>(
+			mongoTemplate.find(Query.query(Criteria.where("chatRoomId").is(ROOM_ID)),
+				ChatMessage.class));
+		messages.sort(Comparator.comparing(ChatMessage::getCreatedAt));
+
+		long inversions = 0;
+		int previous = -1;
+		for (ChatMessage message : messages) {
+			int current = Integer.parseInt(message.getContent());
+			if (current < previous) {
+				inversions++;
+			}
+			previous = current;
+		}
+		return inversions;
+	}
+
+	@Test
+	@DisplayName("한 사람이 연속으로 보내면 시각만으로는 순서가 뒤집힌다")
+	void timestampAloneDoesNotPreserveOrder() throws Exception {
+		sendConcurrently(200, 8);
+
+		long inversions = inversionsWhenSortedByTime();
+
+		// 이 테스트는 결함을 드러내는 것이 목적이라 뒤집힘이 나와야 통과한다.
+		// 고친 뒤에는 번호로 정렬하므로 이 값이 무엇이든 순서가 맞는다.
+		System.out.println("[측정] 200건 중 뒤집힌 횟수 = " + inversions);
+		assertThat(inversions)
+			.as("보낸 순서 200건을 시각으로 정렬했을 때 뒤집힌 횟수")
+			.isPositive();
+	}
+
+	@Test
+	@DisplayName("방마다 늘어나는 번호를 붙이면 뒤집히지 않는다")
+	void sequencePreservesOrder() throws Exception {
+		// 번호는 Redis 증가 연산으로 받는다. 여기서는 그 성질만 흉내 낸다.
+		// 하나씩 늘어나고 같은 값이 두 번 나가지 않는다.
+		java.util.concurrent.atomic.AtomicLong sequence = new java.util.concurrent.atomic.AtomicLong();
+
+		ExecutorService pool = Executors.newFixedThreadPool(8);
+		List<Callable<Void>> tasks = IntStream.range(0, 200)
+			.<Callable<Void>>mapToObj(i -> () -> {
+				ChatMessage message = ChatMessage.createTextMessage(
+					ROOM_ID, SENDER_ID, "m", null);
+				message.setCreatedAt(Instant.now());
+				message.assign(sequence.incrementAndGet(), null);
+				mongoTemplate.save(message);
+				return null;
+			}).toList();
+		pool.invokeAll(tasks);
+		pool.shutdown();
+		pool.awaitTermination(30, TimeUnit.SECONDS);
+
+		List<ChatMessage> messages = new ArrayList<>(
+			mongoTemplate.find(Query.query(Criteria.where("chatRoomId").is(ROOM_ID)),
+				ChatMessage.class));
+		messages.sort(Comparator.comparing(ChatMessage::getSequence));
+
+		long inversions = 0;
+		long previous = 0;
+		java.util.Set<Long> seen = new java.util.HashSet<>();
+		for (ChatMessage message : messages) {
+			long current = message.getSequence();
+			if (current < previous) {
+				inversions++;
+			}
+			assertThat(seen.add(current)).as("같은 번호가 두 번 나가면 안 된다").isTrue();
+			previous = current;
+		}
+
+		System.out.println("[측정] 번호로 정렬했을 때 뒤집힌 횟수 = " + inversions);
+		assertThat(inversions).isZero();
+		assertThat(messages).hasSize(200);
+	}
+
+	@Test
+	@DisplayName("같은 밀리초에 저장된 것이 있으면 시각으로는 순서를 가릴 수 없다")
+	void sameInstantCannotBeOrdered() throws Exception {
+		Instant same = Instant.parse("2026-01-01T00:00:00Z");
+		for (int i = 0; i < 10; i++) {
+			ChatMessage message = ChatMessage.createTextMessage(
+				ROOM_ID, SENDER_ID, String.valueOf(i), null);
+			message.setCreatedAt(same);
+			mongoTemplate.save(message);
+		}
+
+		List<ChatMessage> messages = mongoTemplate.find(
+			Query.query(Criteria.where("chatRoomId").is(ROOM_ID)), ChatMessage.class);
+
+		assertThat(messages).extracting(ChatMessage::getCreatedAt)
+			.as("전부 같은 시각이라 무엇이 먼저인지 정할 근거가 없다")
+			.containsOnly(same);
+	}
+}

--- a/backend/src/test/java/com/joying/chat/ordering/MessageSequenceBackfillTest.java
+++ b/backend/src/test/java/com/joying/chat/ordering/MessageSequenceBackfillTest.java
@@ -1,0 +1,162 @@
+package com.joying.chat.ordering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.repository.support.MongoRepositoryFactory;
+import org.testcontainers.containers.MongoDBContainer;
+
+import com.joying.chat.document.ChatMessage;
+import com.joying.chat.repository.ChatMessageRepository;
+import com.joying.chat.service.MessageSequenceBackfill;
+import com.joying.chat.service.MessageSequenceGenerator;
+
+/**
+ * 번호를 도입하기 전에 저장된 메시지를 채우는 일을 잰다.
+ *
+ * <p>이 코드는 서버가 뜰 때 한 번 돌고 끝난다. 틀려도 바로 보이지 않고, 한참 뒤에
+ * 순서가 이상하다는 신고로 돌아온다. 그래서 실제 MongoDB에 넣고 확인한다.
+ *
+ * <p>재는 것은 셋이다. 하나도 빠뜨리지 않는지, 방마다 따로 매기는지, 두 번 돌려도
+ * 같은지. 마지막 것이 중요한 이유는 서버가 여러 대이거나 재시작하면 두 번 돌기
+ * 때문이다.
+ */
+class MessageSequenceBackfillTest {
+
+	private static MongoDBContainer mongo;
+	private static MongoTemplate mongoTemplate;
+	private static ChatMessageRepository repository;
+
+	private MessageSequenceGenerator sequenceGenerator;
+	private MessageSequenceBackfill backfill;
+
+	@BeforeAll
+	static void startMongo() {
+		mongo = new MongoDBContainer("mongo:7.0");
+		mongo.start();
+		mongoTemplate = new MongoTemplate(
+			new SimpleMongoClientDatabaseFactory(mongo.getConnectionString() + "/joying_backfill_test"));
+		repository = new MongoRepositoryFactory(mongoTemplate).getRepository(ChatMessageRepository.class);
+	}
+
+	@AfterAll
+	static void stopMongo() {
+		if (mongo != null) {
+			mongo.stop();
+		}
+	}
+
+	@BeforeEach
+	void clear() {
+		mongoTemplate.dropCollection(ChatMessage.class);
+		sequenceGenerator = mock(MessageSequenceGenerator.class);
+		backfill = new MessageSequenceBackfill(repository, sequenceGenerator);
+	}
+
+	@Test
+	@DisplayName("번호가 없던 메시지에 저장 시각 순서대로 번호가 매겨진다")
+	void 번호가_없던_메시지에_번호를_채운다() {
+		// 같은 밀리초에 저장된 것을 일부러 섞는다. 실제로 그런 문서들이 있다
+		Instant base = Instant.parse("2025-11-01T00:00:00Z");
+		saveWithoutSequence(1L, base);
+		saveWithoutSequence(1L, base);
+		saveWithoutSequence(1L, base.plusMillis(10));
+		saveWithoutSequence(2L, base.plusMillis(5));
+		saveWithoutSequence(2L, base.plusMillis(20));
+
+		backfill.run(null);
+
+		assertThat(repository.countBySequenceIsNull()).isZero();
+
+		List<Long> room1 = sequencesOf(1L);
+		List<Long> room2 = sequencesOf(2L);
+
+		System.out.println("[측정] 방 1의 번호 = " + room1);
+		System.out.println("[측정] 방 2의 번호 = " + room2);
+
+		// 방마다 1부터 다시 매긴다. 번호는 방 안에서만 의미가 있다
+		assertThat(room1).containsExactly(1L, 2L, 3L);
+		assertThat(room2).containsExactly(1L, 2L);
+
+		// 새 메시지가 뒤에 붙도록 방마다 시작값을 올려 둔다
+		verify(sequenceGenerator).seedAtLeast(1L, 3L);
+		verify(sequenceGenerator).seedAtLeast(2L, 2L);
+	}
+
+	@Test
+	@DisplayName("두 번 돌려도 번호가 다시 매겨지지 않는다")
+	void 두_번_돌려도_같다() {
+		Instant base = Instant.parse("2025-11-01T00:00:00Z");
+		for (int i = 0; i < 5; i++) {
+			saveWithoutSequence(1L, base.plusMillis(i));
+		}
+
+		backfill.run(null);
+		List<Long> first = sequencesOf(1L);
+
+		backfill.run(null);
+		List<Long> second = sequencesOf(1L);
+
+		System.out.println("[측정] 첫 실행 = " + first + ", 두 번째 실행 = " + second);
+		assertThat(second).isEqualTo(first);
+	}
+
+	@Test
+	@DisplayName("이미 번호가 있는 메시지가 섞여 있으면 그 뒤에서 이어 붙는다")
+	void 이미_번호가_있으면_이어_붙인다() {
+		Instant base = Instant.parse("2025-11-01T00:00:00Z");
+
+		// 번호를 도입한 뒤에 들어온 메시지. 이것보다 작은 번호를 다시 내주면 안 된다
+		ChatMessage numbered = message(1L, base.plusMillis(100));
+		numbered.assign(7L, null);
+		repository.save(numbered);
+
+		saveWithoutSequence(1L, base);
+		saveWithoutSequence(1L, base.plusMillis(1));
+
+		backfill.run(null);
+
+		List<Long> all = sequencesOf(1L);
+		System.out.println("[측정] 이어 붙인 뒤 번호 = " + all);
+
+		assertThat(all).doesNotHaveDuplicates();
+		assertThat(all).contains(7L, 8L, 9L);
+		verify(sequenceGenerator).seedAtLeast(1L, 9L);
+	}
+
+	/** 방의 번호를 오름차순으로. 지운 것도 번호를 차지하므로 전부 본다 */
+	private List<Long> sequencesOf(Long chatRoomId) {
+		List<Long> sequences = new ArrayList<>();
+		for (ChatMessage message : repository.findAll()) {
+			if (chatRoomId.equals(message.getChatRoomId()) && message.getSequence() != null) {
+				sequences.add(message.getSequence());
+			}
+		}
+		sequences.sort(Comparator.naturalOrder());
+		return sequences;
+	}
+
+	private void saveWithoutSequence(Long chatRoomId, Instant createdAt) {
+		repository.save(message(chatRoomId, createdAt));
+	}
+
+	private ChatMessage message(Long chatRoomId, Instant createdAt) {
+		ChatMessage message = ChatMessage.createTextMessage(chatRoomId, 100L, "옛날 메시지", null);
+		message.setCreatedAt(createdAt);
+		return message;
+	}
+}

--- a/frontend/src/features/chat/api/websocketApi.js
+++ b/frontend/src/features/chat/api/websocketApi.js
@@ -87,6 +87,19 @@ const createSocket = () => {
   }
 };
 
+/**
+ * 이 전송을 가리키는 값을 만든다.
+ *
+ * 같은 값이 두 번 나오면 안 된다. 브라우저가 주는 것을 쓰되, 없는 환경도 있으므로
+ * 시각과 난수를 붙인 것으로 대신한다.
+ */
+export const newClientMessageId = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+};
+
 export const websocketApi = {
   connect(chatRoomId, { onMessage, onTyping, onRead, onError, onConnect, onDisconnect } = {}) {
     const chatRoomIdNum = Number(chatRoomId);
@@ -241,10 +254,22 @@ export const websocketApi = {
       throw new Error('유효하지 않은 채팅방 ID입니다.');
     }
 
+    // 이 전송을 가리키는 값을 붙인다.
+    //
+    // 발행이 실패하면 저장은 됐는데 전달이 안 된 상태가 된다. 그때 사용자가 다시
+    // 보내면 서버가 같은 값을 보고 두 번 저장하지 않는다. 없으면 같은 말풍선이
+    // 두 번 뜬다.
+    const withClientId = {
+      ...message,
+      clientMessageId: message.clientMessageId ?? newClientMessageId()
+    };
+
     client.publish({
       destination: `/app/chat/${chatRoomIdNum}/send`,
-      body: JSON.stringify(message)
+      body: JSON.stringify(withClientId)
     });
+
+    return withClientId.clientMessageId;
   },
 
   sendReadReceipt(chatRoomId) {

--- a/frontend/src/features/chat/contexts/ChatContext.jsx
+++ b/frontend/src/features/chat/contexts/ChatContext.jsx
@@ -7,7 +7,7 @@ import React, { createContext, useContext, useReducer, useEffect, useCallback, u
 import { useQueryClient } from '@tanstack/react-query';
 import { chatApi } from '../api/chatApi';
 import { messageApi } from '../api/messageApi';
-import { websocketApi, getWebSocketUrl } from '../api/websocketApi';
+import { websocketApi, getWebSocketUrl, newClientMessageId } from '../api/websocketApi';
 import { useChatSocket } from '../hooks/useChatSocket';
 import { useAuth } from '@/features/auth/contexts/AuthContext';
 import { QUERY_KEYS } from '@/lib/react-query/queryKeys';
@@ -16,16 +16,39 @@ import SockJS from 'sockjs-client';
 
 const DEFAULT_MESSAGE_PAGE_SIZE = 20;
 
+/**
+ * 서버가 매긴 번호로 세운다.
+ *
+ * 보낸 시각으로 세우면 같은 순간에 오간 두 건의 앞뒤가 화면마다 달라진다. 시각은
+ * 보내는 쪽 기준이라 두 사람의 시계가 다르면 남의 말이 내 말 앞에 끼기도 한다.
+ *
+ * 아직 서버에 닿지 않아 번호가 없는 것은 맨 뒤에 둔다. 방금 내가 보낸 것이므로
+ * 아래에 있는 것이 맞고, 번호를 받으면 제자리를 찾아간다.
+ */
 const sortMessagesAscending = (messages) => {
   return [...messages].sort((a, b) => {
-    const aTime = new Date(a?.timestamp || 0).getTime();
-    const bTime = new Date(b?.timestamp || 0).getTime();
-    return aTime - bTime;
+    const aSeq = a?.sequence;
+    const bSeq = b?.sequence;
+
+    if (aSeq != null && bSeq != null) return aSeq - bSeq;
+    if (aSeq != null) return -1;
+    if (bSeq != null) return 1;
+
+    // 둘 다 아직 번호가 없으면 내가 누른 순서대로
+    return new Date(a?.timestamp || 0).getTime() - new Date(b?.timestamp || 0).getTime();
   });
 };
 
+/**
+ * 같은 전송을 가리키는 키.
+ *
+ * 보낼 때 붙인 식별자를 가장 먼저 본다. 임시로 그려 둔 것과 서버가 돌려준 것이
+ * 같은 값을 들고 있어, 둘을 한 건으로 묶을 수 있다. 예전에는 내용이 같고 5초
+ * 안이면 같은 것으로 봤는데, 같은 말을 두 번 보내면 하나가 사라졌다.
+ */
 const createMessageKey = (message) => {
   if (!message) return 'undefined';
+  if (message.clientMessageId) return `client:${message.clientMessageId}`;
   if (message.id) return String(message.id);
   const senderId = message.senderId ?? message.sender?.id ?? 'unknown';
   const timestamp = message.timestamp ?? 'no-time';
@@ -39,15 +62,12 @@ const mergeMessages = (existing, incoming) => {
 
   existing.forEach((message) => {
     if (!message) return;
-    // ID가 있으면 ID를 키로 사용, 없으면 createMessageKey 사용
-    const key = message.id ? String(message.id) : createMessageKey(message);
-    map.set(key, message);
+    map.set(createMessageKey(message), message);
   });
 
   incoming.forEach((message) => {
     if (!message) return;
-    // ID가 있으면 ID를 키로 사용, 없으면 createMessageKey 사용
-    const key = message.id ? String(message.id) : createMessageKey(message);
+    const key = createMessageKey(message);
     const existingMessage = map.get(key);
     
     // 같은 ID를 가진 메시지가 있으면 기존 메시지를 유지 (중복 방지)
@@ -282,9 +302,12 @@ export const ChatProvider = ({ children }) => {
   /**
    * 끊긴 사이에 온 메시지를 받아 온다.
    *
-   * 마지막으로 받은 메시지의 시각을 커서로 쓴다. 읽음 시각을 쓰면 안 된다.
+   * 마지막으로 받은 메시지의 번호를 커서로 쓴다. 읽음 시각을 쓰면 안 된다.
    * 읽지 않았어도 받은 것은 받은 것이라, 읽음 시각을 쓰면 이미 화면에 있는 것까지
    * 다시 온다.
+   *
+   * 시각이 아니라 번호인 이유는 경계 때문이다. 서버는 커서보다 큰 것만 주는데,
+   * 같은 밀리초에 저장된 메시지가 둘이면 하나가 커서와 같은 값이라 빠진다.
    *
    * 한 번에 받는 양에 상한이 있어, 오래 꺼져 있었으면 다 받을 때까지 이어서 부른다.
    * 상한이 없으면 며칠 꺼 뒀던 사람이 한 번에 수천 건을 받는다.
@@ -294,12 +317,12 @@ export const ChatProvider = ({ children }) => {
     // 아직 아무것도 못 받았으면 메울 것이 없다. 첫 로딩이 알아서 가져온다.
     const lastReceived = [...messages]
       .reverse()
-      .find((message) => message?.createdAt && !String(message.id ?? '').startsWith('temp_'));
+      .find((message) => message?.sequence != null && !String(message.id ?? '').startsWith('temp_'));
     if (!lastReceived) return;
 
     const BATCH_SIZE = 100;
     const MAX_BATCHES = 10;
-    let cursor = lastReceived.createdAt;
+    let cursor = lastReceived.sequence;
     let filled = 0;
 
     try {
@@ -312,7 +335,7 @@ export const ChatProvider = ({ children }) => {
 
         dispatch({ type: 'MERGE_MESSAGES', payload: missed });
         filled += missed.length;
-        cursor = missed[missed.length - 1].createdAt;
+        cursor = missed[missed.length - 1].sequence;
 
         if (missed.length < BATCH_SIZE) break;
       }
@@ -699,6 +722,10 @@ export const ChatProvider = ({ children }) => {
 
     const message = {
       id: messageId,
+      // 화면의 정렬 기준. 서버가 방 안에서 매긴다
+      sequence: rawMessage.sequence ?? null,
+      // 임시로 그려 둔 것과 서버가 돌려준 것을 묶는 값
+      clientMessageId: rawMessage.clientMessageId ?? null,
       chatRoomId: rawMessage.chatRoomId ?? chatRoomOverride?.chatRoomId ?? chatRoomOverride?.id ?? state.currentChatRoom?.chatRoomId ?? state.currentChatRoom?.id ?? null,
       type,
       content: messageContent,
@@ -1116,15 +1143,24 @@ export const ChatProvider = ({ children }) => {
           
           // 본인이 보낸 새 메시지이고 임시 메시지가 있으면 교체
           if (isOwnMessage) {
-            // 임시 메시지(temp_로 시작하거나 status가 'sending'/'pending'인 메시지) 찾기
-            const tempMessage = snapshot.messages.find(
-              (msg) => 
-                (msg.id && msg.id.startsWith('temp_')) || 
-                (msg.status === 'sending' || msg.status === 'pending') &&
-                Number(msg.senderId) === Number(currentUserId) &&
-                msg.content === normalized.content &&
-                Math.abs(new Date(msg.timestamp) - new Date(normalized.timestamp)) < 5000 // 5초 이내
-            );
+            // 보낼 때 붙인 식별자로 임시 메시지를 찾는다. 같은 값을 들고 있으므로
+            // 같은 전송이라는 것이 확실하다.
+            //
+            // 식별자가 없는 것은 이 화면이 뜨기 전에 보낸 것이다. 그때는 예전 방식대로
+            // 내용과 시각으로 찾는다. 같은 말을 5초 안에 두 번 보내면 하나가 사라지는
+            // 방식이라, 식별자가 있을 때는 쓰지 않는다.
+            const tempMessage = snapshot.messages.find((msg) => {
+              if (normalized.clientMessageId && msg.clientMessageId) {
+                return msg.clientMessageId === normalized.clientMessageId;
+              }
+              return (
+                (msg.id && msg.id.startsWith('temp_')) ||
+                ((msg.status === 'sending' || msg.status === 'pending') &&
+                  Number(msg.senderId) === Number(currentUserId) &&
+                  msg.content === normalized.content &&
+                  Math.abs(new Date(msg.timestamp) - new Date(normalized.timestamp)) < 5000)
+              );
+            });
             
             if (tempMessage) {
               // 임시 메시지를 실제 메시지로 교체
@@ -1653,8 +1689,15 @@ export const ChatProvider = ({ children }) => {
         console.log('[ChatContext] 대여 요청 메시지 감지 (optimistic): text -> rental_request');
       }
       
+      // 이 전송을 가리키는 값. 임시 메시지와 서버가 돌려줄 것에 같은 값을 붙여
+      // 두면 내용을 비교하지 않고도 둘이 같은 것임을 알 수 있다.
+      const clientMessageId = payload.clientMessageId ?? newClientMessageId();
+      payload.clientMessageId = clientMessageId;
+
       const optimisticMessage = {
         id: `temp_${Date.now()}`,
+        clientMessageId,
+        sequence: null,
         chatRoomId: roomId,
         type: messageType,
         content: payload.content,


### PR DESCRIPTION
Closes #43

## 무엇이 문제였나

순서를 저장 시각으로 정하고 있었다. 시각은 저장 직전에 앱 서버가 찍는 값이라 같은 밀리초에 들어온 두 건의 앞뒤를 정할 근거가 되지 못한다.

그리고 발행이 실패하면 저장은 됐는데 전달이 안 된 상태가 된다. 사용자가 다시 보내면 문서가 하나 더 생겼다.

## 재 본 것

실 MongoDB 컨테이너에 8개 스레드로 200건을 저장하고 정렬해 뒤집힌 횟수를 셌다.

| 정렬 기준 | 200건 중 뒤집힌 횟수 |
|---|---|
| 저장 시각 | 49 ~ 64 (실행마다 다름) |
| 방 단위 번호 | 0 |

같은 식별자로 16건을 동시에 저장했을 때 남은 문서는 1건이다.

번호 채우기는 두 번 돌려도 결과가 같고(`[1,2,3,4,5]` → `[1,2,3,4,5]`), 이미 7번을 쓴 방에서는 8·9로 이어 붙는다.

## 어떻게 고쳤나

- 방마다 Redis 증가 연산으로 번호를 발급한다. 읽고 더해서 쓰면 그 사이에 낀 요청이 같은 값을 받으므로 연산 하나로 끝낸다
- 읽는 경로의 정렬과 커서를 번호로 옮겼다. 시각을 커서로 쓰면 같은 밀리초에 저장된 하나가 경계에서 조용히 빠진다
- 멱등 판정은 저장소의 유니크 제약에 맡긴다. 애플리케이션 조회로 하면 동시에 들어온 두 요청이 둘 다 없다고 읽고 둘 다 넣는다
- 번호를 도입하기 전에 저장된 문서는 시작할 때 한 번 채운다

## 걸렸던 것

제약을 `sparse`로 걸었더니 식별자 없는 두 건이 부딪혔다. `sparse`는 인덱스 키 중 하나라도 값이 있으면 색인하므로, 복합 인덱스에서는 `chatRoomId`만 있어도 문서가 들어간다. 조건부 인덱스로 바꿨다.

## 안 한 것

안읽음 건수는 아직 시각으로 센다. 읽은 지점을 방 참여자에 시각으로 들고 있어 함께 바꿔야 하는데, 순서와 달리 눈에 보이는 문제로 이어지지 않아 두었다.

## 호환

`GET /chat-rooms/{id}/messages`의 `before`/`after`가 시각에서 번호로 바뀐다. 예전 화면이 시각을 보내면 400으로 떨어진다. 이름을 바꿔서 파라미터가 무시되고 엉뚱한 구간이 오는 것보다 낫다고 봤다.