### PR TITLE
안읽음이 경계에서 3건을 1건으로 세던 것

### DIFF
--- a/backend/src/main/java/com/joying/chat/domain/ChatRoomMember.java
+++ b/backend/src/main/java/com/joying/chat/domain/ChatRoomMember.java
@@ -61,9 +61,22 @@ public class ChatRoomMember extends BaseEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	@Comment("마지막으로 읽은 시각 (UTC). 안읽음 개수를 세는 기준이다")
+	@Comment("마지막으로 읽은 시각 (UTC). 화면에 보여 주는 데 쓴다")
 	@Column(name = "last_read_at")
 	private Instant lastReadAt;
+
+	/**
+	 * 마지막으로 읽은 메시지의 번호.
+	 *
+	 * <p>안읽음을 세는 기준이다. 시각으로 세면 같은 밀리초에 저장된 메시지가 경계에서
+	 * 빠진다. 상대가 같은 순간에 세 건을 보내고 내가 첫 건까지 읽었을 때, 시각으로 세면
+	 * 안 읽은 세 건이 한 건으로 보인다.
+	 *
+	 * <p>번호를 도입하기 전에 읽어 둔 사람은 이 값이 비어 있다. 그때는 시각으로 센다.
+	 */
+	@Comment("마지막으로 읽은 메시지 번호. 안읽음 개수를 세는 기준이다")
+	@Column(name = "last_read_sequence")
+	private Long lastReadSequence;
 
 	@Comment("채팅방 고정 여부")
 	@Column(name = "is_pinned", nullable = false)
@@ -88,6 +101,19 @@ public class ChatRoomMember extends BaseEntity {
 
 	public void markAsRead(Instant readAt) {
 		this.lastReadAt = readAt;
+	}
+
+	/**
+	 * 이 번호까지 읽었다고 표시한다.
+	 *
+	 * <p>뒤로 물러나지 않는다. 오래된 화면이 늦게 읽음을 보내면 이미 읽은 것이 다시
+	 * 안읽음으로 돌아갈 수 있다.
+	 */
+	public void markAsRead(Long sequence, Instant readAt) {
+		this.lastReadAt = readAt;
+		if (sequence != null && (this.lastReadSequence == null || sequence > this.lastReadSequence)) {
+			this.lastReadSequence = sequence;
+		}
 	}
 
 	public void pin() {

--- a/backend/src/main/java/com/joying/chat/repository/ChatMessageRepository.java
+++ b/backend/src/main/java/com/joying/chat/repository/ChatMessageRepository.java
@@ -68,6 +68,15 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
 	List<ChatMessage> findByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanOrderBySequenceAsc(
 		Long chatRoomId, Long after, Pageable pageable);
 
+	/**
+	 * 이 번호 이후, 이 사람이 보내지 않은 메시지 수.
+	 *
+	 * <p>안읽음을 셀 때 쓴다. 시각으로 세면 같은 밀리초에 저장된 메시지가 경계에서
+	 * 빠진다. 읽지 않았는데 읽은 것으로 센다.
+	 */
+	long countByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanAndSenderIdNot(
+		Long chatRoomId, Long afterSequence, Long excludeSenderId);
+
 	/** 같은 전송이 이미 저장돼 있는지 */
 	java.util.Optional<ChatMessage> findByChatRoomIdAndClientMessageId(
 		Long chatRoomId, String clientMessageId);

--- a/backend/src/main/java/com/joying/chat/service/ChatMessageService.java
+++ b/backend/src/main/java/com/joying/chat/service/ChatMessageService.java
@@ -110,9 +110,8 @@ public class ChatMessageService {
 	/**
 	 * 안읽음 건수.
 	 *
-	 * <p>여기만 아직 시각으로 센다. 읽은 지점을 방 참여자에 시각으로 들고 있어서다.
-	 * 같은 밀리초 경계에서 한 건이 어긋날 수 있다. 순서와 달리 눈에 보이는 문제로
-	 * 이어지지 않아 이번에는 손대지 않았다.
+	 * <p>읽은 시각을 받아 그 이후를 센다. 정확히 세는 것은 {@code UnreadCountService}
+	 * 가 읽은 번호로 하고, 여기는 시각만 아는 자리에서 쓴다.
 	 */
 	public long getUnreadCount(Long chatRoomId, Instant lastReadAt) {
 		if (lastReadAt == null) {

--- a/backend/src/main/java/com/joying/chat/service/ChatService.java
+++ b/backend/src/main/java/com/joying/chat/service/ChatService.java
@@ -168,7 +168,15 @@ public class ChatService {
 			.orElseThrow(() -> new BusinessException(
 				ErrorCode.RESOURCE_NOT_FOUND, "채팅방 멤버를 찾을 수 없습니다"));
 
-		chatRoomMember.markAsRead();
+		// 읽은 지점을 방의 마지막 메시지 번호로 잡는다.
+		//
+		// 시각으로 잡으면 같은 밀리초에 저장된 메시지가 경계에서 빠진다. 상대가 같은
+		// 순간에 세 건을 보내고 그중 첫 건의 시각을 기준으로 삼으면, 안 읽은 세 건이
+		// 한 건으로 보인다.
+		ChatMessage newest = chatMessageRepository
+			.findFirstByChatRoomIdAndIsDeletedFalseOrderBySequenceDesc(chatRoomId);
+		chatRoomMember.markAsRead(newest == null ? null : newest.getSequence(), Instant.now());
+
 		unreadCountService.reset(chatRoomId, memberId);
 
 		runQuietly("메시지 읽음 표시", () -> markMessagesRead(chatRoomId, memberId));

--- a/backend/src/main/java/com/joying/chat/service/UnreadCountService.java
+++ b/backend/src/main/java/com/joying/chat/service/UnreadCountService.java
@@ -153,6 +153,35 @@ public class UnreadCountService {
 	}
 
 	/**
+	 * 안 읽은 건수를 센다. 본인이 보낸 것은 어느 쪽이든 뺀다.
+	 *
+	 * <p>읽은 지점을 번호로 잡는다. 시각으로 잡으면 같은 밀리초에 저장된 메시지가
+	 * 경계에서 빠져 읽지 않았는데 읽은 것으로 센다. 세 건이 같은 순간에 왔을 때
+	 * 시각으로는 한 건, 번호로는 세 건이 나온다.
+	 *
+	 * <p>번호를 도입하기 전에 읽어 둔 사람은 번호가 비어 있다. 그때만 시각으로 센다.
+	 * 그 사람이 한 번 더 읽으면 번호가 채워지고 그 뒤로는 정확해진다.
+	 */
+	private long countUnread(ChatRoomMember member, Long chatRoomId, Long memberId) {
+		if (member.getLastReadSequence() != null) {
+			return chatMessageRepository
+				.countByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanAndSenderIdNot(
+					chatRoomId, member.getLastReadSequence(), memberId);
+		}
+
+		if (member.getLastReadAt() == null) {
+			// 읽은 지점이 없다는 것은 한 번도 안 읽었다는 뜻이지 읽을 것이 없다는
+			// 뜻이 아니다. 방의 처음부터 전부 센다
+			return chatMessageRepository
+				.countByChatRoomIdAndIsDeletedFalseAndSenderIdNot(chatRoomId, memberId);
+		}
+
+		return chatMessageRepository
+			.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(
+				chatRoomId, member.getLastReadAt(), memberId);
+	}
+
+	/**
 	 * 저장소에서 세어 Redis에 다시 넣는다.
 	 *
 	 * <p>읽은 시각이 없다는 것은 한 번도 안 읽었다는 뜻이지 읽을 것이 없다는 뜻이
@@ -170,13 +199,7 @@ public class UnreadCountService {
 				return 0L;
 			}
 
-			// 본인이 보낸 것은 어느 쪽이든 빼고 센다
-			long actualCount = member.getLastReadAt() == null
-				? chatMessageRepository
-					.countByChatRoomIdAndIsDeletedFalseAndSenderIdNot(chatRoomId, memberId)
-				: chatMessageRepository
-					.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(
-						chatRoomId, member.getLastReadAt(), memberId);
+			long actualCount = countUnread(member, chatRoomId, memberId);
 
 			try {
 				redis.opsForValue().set(getKey(chatRoomId, memberId),

--- a/backend/src/test/java/com/joying/chat/ordering/UnreadCountBoundaryTest.java
+++ b/backend/src/test/java/com/joying/chat/ordering/UnreadCountBoundaryTest.java
@@ -1,0 +1,128 @@
+package com.joying.chat.ordering;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.repository.support.MongoRepositoryFactory;
+import org.testcontainers.containers.MongoDBContainer;
+
+import com.joying.chat.document.ChatMessage;
+import com.joying.chat.repository.ChatMessageRepository;
+
+/**
+ * 읽은 지점을 시각으로 잡으면 경계에서 한 건이 어긋난다.
+ *
+ * <p>안읽음은 읽은 시각 이후를 센다. 그런데 같은 밀리초에 저장된 메시지가 여럿이면
+ * 그중 어디까지 읽었는지를 시각으로 가릴 수 없다.
+ *
+ * <p>읽은 시각을 마지막으로 읽은 메시지의 시각으로 잡으면, 같은 시각에 저장된 다른
+ * 메시지들이 "이후" 조건에서 빠진다. 읽지 않았는데 읽은 것으로 센다.
+ *
+ * <p>같은 밀리초에 메시지가 여럿 저장되는 것은 앞선 실험에서 확인했다. 8개 스레드로
+ * 200건을 저장하면 시각만으로는 순서를 정할 수 없을 만큼 겹친다.
+ */
+class UnreadCountBoundaryTest {
+
+	private static MongoDBContainer mongo;
+	private static MongoTemplate mongoTemplate;
+	private static ChatMessageRepository repository;
+
+	private static final long ROOM_ID = 1L;
+	private static final long ME = 100L;
+	private static final long OTHER = 200L;
+
+	@BeforeAll
+	static void startMongo() {
+		mongo = new MongoDBContainer("mongo:7.0");
+		mongo.start();
+		mongoTemplate = new MongoTemplate(
+			new SimpleMongoClientDatabaseFactory(mongo.getConnectionString() + "/joying_unread_test"));
+		repository = new MongoRepositoryFactory(mongoTemplate).getRepository(ChatMessageRepository.class);
+	}
+
+	@AfterAll
+	static void stopMongo() {
+		if (mongo != null) {
+			mongo.stop();
+		}
+	}
+
+	@BeforeEach
+	void clear() {
+		mongoTemplate.dropCollection(ChatMessage.class);
+	}
+
+	@Test
+	@DisplayName("같은 시각에 저장된 메시지가 경계에 걸리면 시각으로는 덜 센다")
+	void 시각으로_세면_경계에서_덜_센다() {
+		// 상대가 같은 밀리초에 세 건을 보냈다. 실제로 일어나는 일이다
+		Instant sameMoment = Instant.parse("2026-08-01T00:00:00Z");
+		save(1L, OTHER, sameMoment);
+		save(2L, OTHER, sameMoment);
+		save(3L, OTHER, sameMoment);
+		// 그 뒤에 한 건 더
+		save(4L, OTHER, sameMoment.plusMillis(10));
+
+		// 내가 1번까지 읽었다. 읽은 지점을 그 메시지의 시각으로 잡는다
+		Instant lastReadAt = sameMoment;
+
+		long byTime = repository
+			.countByChatRoomIdAndIsDeletedFalseAndCreatedAtAfterAndSenderIdNot(ROOM_ID, lastReadAt, ME);
+		long bySequence = repository
+			.countByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanAndSenderIdNot(ROOM_ID, 1L, ME);
+
+		System.out.println("[측정] 시각으로 센 안읽음 = " + byTime + ", 번호로 센 안읽음 = " + bySequence);
+
+		// 안 읽은 것은 2·3·4번 세 건이다
+		assertThat(bySequence).isEqualTo(3);
+		// 시각으로 세면 같은 시각인 2·3번이 빠져 한 건만 센다
+		assertThat(byTime).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("본인이 보낸 것은 번호로 셀 때도 빠진다")
+	void 본인이_보낸_것은_빠진다() {
+		Instant base = Instant.parse("2026-08-01T00:00:00Z");
+		save(1L, OTHER, base);
+		save(2L, ME, base.plusMillis(1));
+		save(3L, OTHER, base.plusMillis(2));
+
+		long unread = repository
+			.countByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanAndSenderIdNot(ROOM_ID, 1L, ME);
+
+		System.out.println("[측정] 내 것을 뺀 안읽음 = " + unread);
+		assertThat(unread).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("한 번도 읽지 않았으면 방의 처음부터 센다")
+	void 한_번도_안_읽었으면_전부_센다() {
+		Instant base = Instant.parse("2026-08-01T00:00:00Z");
+		save(1L, OTHER, base);
+		save(2L, OTHER, base.plusMillis(1));
+		save(3L, ME, base.plusMillis(2));
+
+		// 읽은 지점이 없을 때는 0번보다 큰 것을 전부 센다
+		long unread = repository
+			.countByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanAndSenderIdNot(ROOM_ID, 0L, ME);
+
+		System.out.println("[측정] 한 번도 안 읽었을 때 = " + unread);
+		assertThat(unread).isEqualTo(2);
+	}
+
+	private void save(long sequence, long senderId, Instant createdAt) {
+		ChatMessage message = ChatMessage.createTextMessage(ROOM_ID, senderId, "메시지 " + sequence, null);
+		message.setCreatedAt(createdAt);
+		message.assign(sequence, null);
+		repository.save(message);
+	}
+}

--- a/backend/src/test/java/com/joying/chat/service/UnreadCountServiceTest.java
+++ b/backend/src/test/java/com/joying/chat/service/UnreadCountServiceTest.java
@@ -110,10 +110,30 @@ class UnreadCountServiceTest {
 	}
 
 	@Test
-	@DisplayName("캐시가 비었으면 저장소에서 세되 본인이 보낸 것은 빼고 센다")
+	@DisplayName("캐시가 비었으면 읽은 번호 이후를 세되 본인이 보낸 것은 뺀다")
 	void countsOnlyMessagesFromOthers() {
+		// 읽은 지점을 번호로 잡는다. 시각으로 잡으면 같은 밀리초에 저장된 메시지가
+		// 경계에서 빠져 읽지 않았는데 읽은 것으로 센다
+		ChatRoomMember member = org.mockito.Mockito.mock(ChatRoomMember.class);
+		given(member.getLastReadSequence()).willReturn(42L);
+
+		given(valueOps.get(KEY)).willReturn(null);
+		given(memberRepository.findByChatRoomIdAndMemberId(ROOM_ID, MEMBER_ID))
+			.willReturn(Optional.of(member));
+		given(messageRepository.countByChatRoomIdAndIsDeletedFalseAndSequenceGreaterThanAndSenderIdNot(
+			ROOM_ID, 42L, MEMBER_ID)).willReturn(3L);
+
+		assertThat(service.get(ROOM_ID, MEMBER_ID)).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("번호를 도입하기 전에 읽어 둔 사람은 시각으로 센다")
+	void fallsBackToTimeWhenSequenceIsMissing() {
+		// 번호가 없는 사람이 남아 있다. 그 사람이 한 번 더 읽으면 번호가 채워지고
+		// 그 뒤로는 정확해진다
 		Instant lastReadAt = Instant.parse("2026-01-01T00:00:00Z");
 		ChatRoomMember member = org.mockito.Mockito.mock(ChatRoomMember.class);
+		given(member.getLastReadSequence()).willReturn(null);
 		given(member.getLastReadAt()).willReturn(lastReadAt);
 
 		given(valueOps.get(KEY)).willReturn(null);
@@ -132,6 +152,7 @@ class UnreadCountServiceTest {
 		// 아니다. 예전에는 여기서 저장소를 보지 않고 0을 돌려줬고, 그래서 새로 만든
 		// 방에 상대가 먼저 말을 걸면 배지에 아무것도 안 떴다.
 		ChatRoomMember member = org.mockito.Mockito.mock(ChatRoomMember.class);
+		given(member.getLastReadSequence()).willReturn(null);
 		given(member.getLastReadAt()).willReturn(null);
 
 		given(valueOps.get(KEY)).willReturn(null);


### PR DESCRIPTION
Closes #60

## 재현

상대가 같은 순간에 세 건을 보내고 내가 첫 건까지 읽은 상황을 만들었다.

| 세는 기준 | 안읽음 |
|---|---|
| 읽은 시각 | 1 |
| 읽은 번호 | **3** |

안 읽은 것은 세 건인데 시각으로는 한 건으로 센다.

같은 밀리초에 메시지가 여럿 저장되는 것은 앞선 실험에서 확인했다. 8개 스레드로 200건을 저장하면 시각만으로는 순서를 정할 수 없을 만큼 겹친다.

## 어떻게 고쳤나

방 참여자에 읽은 번호를 두고 그 이후를 센다. 읽음 표시를 할 때 방의 마지막 메시지 번호를 기록한다.

번호는 뒤로 물러나지 않는다. 오래된 화면이 늦게 읽음을 보내면 이미 읽은 것이 다시 안읽음으로 돌아갈 수 있다.

## 옛 데이터

번호를 도입하기 전에 읽어 둔 사람은 값이 비어 있다. 그때만 시각으로 센다. 한 번 더 읽으면 번호가 채워지고 그 뒤로는 정확해진다.

일괄로 채우지 않았다. **읽은 시각으로 번호를 되짚는 것은 지금 고치려는 그 모호함을 다시 쓰는 일이다.** 같은 시각에 여러 건이 있으면 어느 번호까지 읽었는지 알 수 없다.

## 테스트

기존 테스트가 시각으로 세는 것을 기대하고 있어 새 동작에 맞게 다시 썼다. 읽은 번호가 있는 경우, 번호가 없고 시각만 있는 경우, 둘 다 없는 경우 세 갈래를 덮는다.

전체 86건 통과 (+4).