### PR TITLE
ci: 커버리지를 재되 기준을 걸지 않는다

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: 테스트
         working-directory: backend
-        run: ./gradlew test --no-daemon
+        run: ./gradlew test jacocoTestReport --no-daemon
 
       # 실패했을 때 어느 테스트가 왜 깨졌는지 보려면 결과 파일이 필요하다.
       # 성공했을 때도 올려 둔다. 몇 건이 돌았는지 확인할 수 있다
@@ -55,6 +55,7 @@ jobs:
           path: |
             backend/build/reports/tests/test
             backend/build/test-results/test
+            backend/build/reports/jacoco/test/html
           retention-days: 7
 
       - name: 요약
@@ -73,4 +74,25 @@ jobs:
           print()
           print(f'- 실패 {failed}건')
           print(f'- 건너뜀 {skipped}건')
+
+          # 커버리지는 문을 걸지 않고 보여 주기만 한다. 이 프로젝트의 테스트는 결함을
+          # 재현하려고 쓴 것이 많아, 숫자를 올리는 것이 목적이 되면 재현과 상관없는
+          # 테스트가 늘어난다
+          try:
+              xml = open('build/reports/jacoco/test/jacocoTestReport.xml', encoding='utf-8').read()
+          except FileNotFoundError:
+              raise SystemExit
+          counters = re.findall(r'<counter type="(LINE|BRANCH)" missed="(\d+)" covered="(\d+)"/>', xml)
+          summary = {}
+          for kind, missed, covered in counters:
+              summary[kind] = (int(missed), int(covered))
+          print()
+          print('## 커버리지 (참고용, 기준을 걸지 않는다)')
+          print()
+          for kind in ('LINE', 'BRANCH'):
+              if kind in summary:
+                  missed, covered = summary[kind]
+                  whole = missed + covered
+                  if whole:
+                      print(f'- {kind.lower()} {covered}/{whole} ({covered * 100 // whole}%)')
           PY

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     java
     id("org.springframework.boot") version "3.5.6"
+    // 테스트가 어디를 지나는지 본다. 숫자로 문을 걸지는 않는다
+    jacoco
     id("io.spring.dependency-management") version "1.1.7"
     id("io.freefair.lombok") version "8.11" // Java Lombok annotation processing용
 }
@@ -126,4 +128,33 @@ tasks.withType<Test> {
         showStandardStreams = false
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
+}
+
+// 테스트가 끝나면 커버리지 보고서를 만든다.
+//
+// 기준을 걸어 빌드를 깨지는 않는다. 이 프로젝트의 테스트는 결함을 재현하려고 쓴 것이
+// 많아, 숫자를 올리는 것이 목적이 되면 재현과 상관없는 테스트가 늘어난다. 지금은
+// 어디가 비어 있는지 보는 데만 쓴다.
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                // 설정과 DTO 는 분기가 없어 커버리지에 잡혀도 뜻이 없다
+                exclude(
+                    "**/config/**",
+                    "**/dto/**",
+                    "**/JoyingApplication*",
+                )
+            }
+        })
+    )
 }


### PR DESCRIPTION
## 왜

테스트 86건이 어디를 지나는지 볼 방법이 없다.

## 기준을 걸지 않은 이유

이 프로젝트의 테스트는 **결함을 재현하려고 쓴 것**이 많다. 순서가 뒤집히는 것, 같은 전송이 두 건이 되는 것, 안읽음이 덜 세지는 것.

숫자를 올리는 것이 목적이 되면 재현과 상관없는 테스트가 늘어난다. 지금은 어디가 비어 있는지 보는 데만 쓴다.

## 지금 값

라인 16%, 분기 5%. 낮지만 그게 사실이다.

| 패키지 | 라인 커버리지 |
|---|---|
| escrow/service | 43% |
| payment/domain | 25% |
| chat/service | 17% |
| product/service | 11% |
| rental/service | 5% |
| common/exception | 1% |

리팩토링하며 손댄 자리에는 테스트가 있고 손대지 않은 자리에는 없다. 그 분포가 그대로 보인다.

설정과 DTO는 제외했다. 분기가 없어 커버리지에 잡혀도 뜻이 없고, 넣으면 숫자만 올라간다.